### PR TITLE
draw chaos token

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1703,11 +1703,20 @@ def drawPileToTable(group, x, y):
     card = group[0]
     card.moveToTable(x, y)
     notify("{} draws {} from the {}.".format(me, card.name, group.name))
+    return card
 
 def drawChaosToken(group, x = 0, y = 0):
     mute()
+    # check for existing chaos token on table
+    lastTokenId = getGlobalVariable("drawnChaosToken")
+    if lastTokenId:
+        lastToken = Card(int(lastTokenId))
+        lastToken.moveTo(chaosBag())
+        setGlobalVariable("drawnChaosToken", "")
+
     chaosBag().shuffle()
-    drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)
+    card = drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)
+    setGlobalVariable("drawnChaosToken", card._id)
 
 # def captureDeck(group):
 #   if len(group) == 0: return

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -22,6 +22,8 @@ ActX = 292.647
 ActY = -189.234
 ScenarioX = 418.517
 ScenarioY = -190.791
+ChaosTokenX = 55
+ChaosTokenY = -230
 DoneColour = "#D8D8D8" # Grey
 WaitingColour = "#FACC2E" # Orange
 ActiveColour = "#82FA58" # Green
@@ -1682,15 +1684,30 @@ def shuffleCardsIntoDeck(group):
         owner.deck.shuffle()
 
 def swapWithEncounter(group):
-  mute()
-  if confirm("Swap all cards from {} with those in Encounter Deck?".format(group.name)):
-    deck = encounterDeck()
-    size = len(deck)
-    for c in group:
-        c.moveToBottom(deck)
-    for c in deck.top(size):
-        c.moveToBottom(group)
-    notify("{} swaps {} and Encounter Deck.".format(me, group.name))
+    mute()
+    if confirm("Swap all cards from {} with those in Encounter Deck?".format(group.name)):
+      deck = encounterDeck()
+      size = len(deck)
+      for c in group:
+          c.moveToBottom(deck)
+      for c in deck.top(size):
+          c.moveToBottom(group)
+      notify("{} swaps {} and Encounter Deck.".format(me, group.name))
+
+def drawPileToTable(group, x, y):
+    mute()
+    if len(group) == 0:
+        notify("{} is empty.".format(group.name))
+        return
+
+    card = group[0]
+    card.moveToTable(x, y)
+    notify("{} draws {} from the {}.".format(me, card.name, group.name))
+
+def drawChaosToken(group):
+    mute()
+    group.shuffle()
+    drawPileToTable(group, ChaosTokenX, ChaosTokenY)
 
 # def captureDeck(group):
 #   if len(group) == 0: return

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1710,7 +1710,11 @@ def drawChaosToken(group, x = 0, y = 0):
     # check for existing chaos token on table
     table_chaos_tokens = [card for card in table
         if card.Type == 'Chaos Token']
-    for token in table_chaos_tokens: token.moveTo(chaosBag())
+    for token in table_chaos_tokens:
+        if token.controller == me:
+            token.moveTo(chaosBag())
+        else:
+            remoteCall(token.controller, "moveTo", chaosBag())
 
     chaosBag().shuffle()
     card = drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1704,10 +1704,10 @@ def drawPileToTable(group, x, y):
     card.moveToTable(x, y)
     notify("{} draws {} from the {}.".format(me, card.name, group.name))
 
-def drawChaosToken(group):
+def drawChaosToken(group, x = 0, y = 0):
     mute()
-    group.shuffle()
-    drawPileToTable(group, ChaosTokenX, ChaosTokenY)
+    chaosBag().shuffle()
+    drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)
 
 # def captureDeck(group):
 #   if len(group) == 0: return

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1708,11 +1708,9 @@ def drawPileToTable(group, x, y):
 def drawChaosToken(group, x = 0, y = 0):
     mute()
     # check for existing chaos token on table
-    lastTokenId = getGlobalVariable("drawnChaosToken")
-    if lastTokenId:
-        lastToken = Card(int(lastTokenId))
-        lastToken.moveTo(chaosBag())
-        setGlobalVariable("drawnChaosToken", "")
+    table_chaos_tokens = [card for card in table
+        if card.Type == 'Chaos Token']
+    for token in table_chaos_tokens: token.moveTo(chaosBag())
 
     chaosBag().shuffle()
     card = drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -40,7 +40,6 @@
 		<globalvariable name="deckLocked" value="" />
 		<globalvariable name="firstPlayer" value="" />
 		<globalvariable name="activePlayer" value="" />
-		<globalvariable name="drawnChaosToken" value="" /> <!-- used to keep track of chaos tokens, so it can be shuffled back into the bag -->
 	</globalvariables>
 	<card back="cards/card.jpg" front="cards/card.jpg" width="63" height="88" cornerRadius="4">
 		<property name="Unique" type="String" hidden="False" ignoreText="False" />

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -81,6 +81,7 @@
 		<groupaction menu="Reveal Encounter Card (Special Deck)" default="False" shortcut="ctrl+shift+E" execute="addEncounterSpecial" />
 		<groupaction menu="Hidden Encounter Card" default="False" shortcut="ctrl+H" execute="addHidden" />
 		<groupaction menu="Hidden Encounter Card (Special Deck)" default="False" shortcut="ctrl+shift+H" execute="addHiddenSpecial" />
+		<groupaction menu="Draw Token from ChaosBag" default="False" shortcut="ctrl+S" execute="drawChaosToken" />
 		<groupaction menu="Ready to Refresh" default="False" shortcut="ctrl+R" execute="readyForRefresh" />
 		<groupaction menu="Ready for next round" default="False" shortcut="ctrl+N" execute="readyForNextRound" />
 		<groupaction menu="Clear Targets" default="False" shortcut="Esc" execute="clearTargets" />

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -40,6 +40,7 @@
 		<globalvariable name="deckLocked" value="" />
 		<globalvariable name="firstPlayer" value="" />
 		<globalvariable name="activePlayer" value="" />
+		<globalvariable name="drawnChaosToken" value="" /> <!-- used to keep track of chaos tokens, so it can be shuffled back into the bag -->
 	</globalvariables>
 	<card back="cards/card.jpg" front="cards/card.jpg" width="63" height="88" cornerRadius="4">
 		<property name="Unique" type="String" hidden="False" ignoreText="False" />


### PR DESCRIPTION
This adds the ability to draw a Chaos Token from the Chaos "Bag". If you double click on the global "Chaos Bag" pile, it will shuffle the pile before drawing a new one. In addition, "Ctrl+S" draws a new Chaos Token. I was just trying to pick a shortcut that wasn't used but open to suggestions. There's an option listed under the Table menu. Finally, if an existing token on the board already exists, it will automatically shuffle that one back in before drawing a new one, so there's no need to manually discard when doing multiple tests.