### PR TITLE
draw token should not blow up when the bag is empty

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1719,8 +1719,7 @@ def drawChaosToken(group, x = 0, y = 0):
             remoteCall(token.controller, "moveTo", chaosBag())
 
     chaosBag().shuffle()
-    card = drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)
-    setGlobalVariable("drawnChaosToken", card._id)
+    drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)
 
 # def captureDeck(group):
 #   if len(group) == 0: return


### PR DESCRIPTION
Currently, when drawing a chaos token blows up if the chaos bag is empty. This guards that.