### PR TITLE
Draw act/agenda

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1036,6 +1036,8 @@ def agendaSetup(card):
             #   makeActive(c)
             #   setReminders(c)
             i += 1
+def nextAgenda(group = None, x = 0, y = 0):
+    nextAgendaStage(group, x, y)
 
 def nextActStage(group=None, x=0, y=0):
     mute()
@@ -1068,6 +1070,9 @@ def nextActStage(group=None, x=0, y=0):
     
 #   actSetup(card)
     notify("{} advances act to '{}'".format(me, card))
+
+def nextAct(group = None, x = 0, y = 0):
+    nextActStage(group, x, y)
 
 # def readyForNextRound(group=table, x=0, y=0):
 #   mute()


### PR DESCRIPTION
This simply calls the `nextActStage` and `nextAgendaStage` functions when double clicked on. I'm not sure if you wanted it to put the card on top of the existing Act/Agenda. I assumed so, since there's a nice spot for it in the "book". Secondly, it first flips to Side B if Side A is showing. This means you'll need to double click twice to get an Agenda or Act replaced.