### PR TITLE
Basic Weakness

### DIFF
--- a/o8g/Decks/01 - Core/Basic Weaknesses.o8d
+++ b/o8g/Decks/01 - Core/Basic Weaknesses.o8d
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf" sleeveid="0">
+  <section name="Investigator" shared="False" />
+  <section name="Basic Weakness" shared="True">
+    <card qty="2" id="9ca5f0a3-e74f-4068-bf67-9fe003cf17c0">Paranoia</card>
+    <card qty="2" id="8398d095-9e12-45dd-8242-838ed636ba1d">Amnesia</card>
+    <card qty="1" id="76d61a65-4c3a-486c-b507-c4b0a109d65f">Haunted</card>
+    <card qty="1" id="f8c80be5-04a4-4546-8d16-6d6c6a0d21ec">Psychosis</card>
+    <card qty="1" id="5f5c0fc7-34ce-45ce-a609-f2b4f4fc6e5a">Hypochondria</card>
+    <card qty="1" id="22a5a1f6-cc50-47a9-9374-76204c97cf0a">Mob Enforcer</card>
+    <card qty="1" id="9b1de9f2-b050-41c4-bfdc-16a40974a3fb">Silver Twilight Acolyte</card>
+    <card qty="1" id="d5b68cab-54f1-488c-ba9f-68d8830cf2d0">Stubborn Detective</card>
+  </section>
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Agenda" shared="True" />
+  <section name="Act" shared="True" />
+  <section name="Encounter" shared="True" />
+  <section name="Location" shared="True" />
+  <section name="Special" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Chaos Bag" shared="True" />
+  <section name="Setup" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1736,6 +1736,19 @@ def drawChaosToken(group, x = 0, y = 0):
     chaosBag().shuffle()
     drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)
 
+def drawWeakness(group, x = 0, y = 0):
+    mute()
+    pile = shared.piles['Basic Weakness']
+    if len(pile) == 0:
+        notify("{} is {empty.".format(pile))
+        return
+
+    notify("{} drew a random basic weakness into deck".format(me))
+    pile.shuffle()
+    card = pile.top()
+    card.moveTo(me.deck)
+    me.deck.shuffle()
+
 # def captureDeck(group):
 #   if len(group) == 0: return
 #   mute()

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1738,15 +1738,10 @@ def drawChaosToken(group, x = 0, y = 0):
 
 def drawWeakness(group, x = 0, y = 0):
     mute()
-    pile = shared.piles['Basic Weakness']
-    if len(pile) == 0:
-        notify("{} is {empty.".format(pile))
-        return
 
-    notify("{} drew a random basic weakness into deck".format(me))
-    pile.shuffle()
-    card = pile.top()
-    card.moveTo(me.deck)
+    guid = BasicWeakness.draw()
+    card = me.deck.create(guid)
+    notify("{} shuffles a random Basic Weakness into deck".format(me))
     me.deck.shuffle()
 
 # def captureDeck(group):

--- a/o8g/Scripts/basic_weakness.py
+++ b/o8g/Scripts/basic_weakness.py
@@ -1,0 +1,28 @@
+class BasicWeakness:
+    CARDS = {
+        "core": [
+            "9ca5f0a3-e74f-4068-bf67-9fe003cf17c0", # 2 x Paranoia,
+            "9ca5f0a3-e74f-4068-bf67-9fe003cf17c0",
+            "8398d095-9e12-45dd-8242-838ed636ba1d", # 2 x Amnesia,
+            "8398d095-9e12-45dd-8242-838ed636ba1d",
+            "76d61a65-4c3a-486c-b507-c4b0a109d65f", # Haunted
+            "f8c80be5-04a4-4546-8d16-6d6c6a0d21ec", # Psychosis
+            "5f5c0fc7-34ce-45ce-a609-f2b4f4fc6e5a", # Hypochondria
+            "22a5a1f6-cc50-47a9-9374-76204c97cf0a", # Mob Enforcer
+            "9b1de9f2-b050-41c4-bfdc-16a40974a3fb", # Silver Twilight Acolyte
+            "d5b68cab-54f1-488c-ba9f-68d8830cf2d0", # Stubborn Detective
+        ]
+    }
+
+    @classmethod
+    def draw(cls, sets = "all"):
+        picked_weaknesses = []
+
+        if sets == "all":
+            for name, cards in cls.CARDS.iteritems():
+                picked_weaknesses += cards
+        else:
+            for cards in (cards for name, cards in cls.CARDS.iteritems() if name in sets):
+                picked_weaknesses += cards
+
+        return picked_weaknesses[rnd(0, len(picked_weaknesses) - 1)]

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -212,6 +212,9 @@
 		</group>
 		<group name="Setup" visibility="all" ordered="True" width="63" height="88" icon="groups/encounterS.png" collapsed="True">
 		</group>
+		<group name="Basic Weakness" visibility="none" ordered="True" width="63" height="88" icon="groups/player.png" collapsed="True">
+			<groupaction menu="Draw Random Weakness into Your Deck" default="True" execute="drawWeakness" />
+		</group>
 	</shared>
 	<deck>
 		<section name="Investigator" group="Hand" />
@@ -230,5 +233,6 @@
 		<section name="Second Special" group="2nd Special" />		
 		<section name="Chaos Bag" group="Chaos Bag" />
 		<section name="Setup" group="Setup" />
+		<section name="Basic Weakness" group="Basic Weakness" />
 	</sharedDeck>
 </game>

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -16,6 +16,7 @@
 	usetwosidedtable="False">
 	<scripts>
 		<script src="scripts/actions.py" />
+		<script src="scripts/basic_weakness.py" />
 	</scripts>
 	<events>
 		<event name="OnGameStarted" action="startOfGame"/>
@@ -143,6 +144,7 @@
 			<groupaction menu="Discard Many" default="False" execute="discardMany" />
 			<groupaction menu="Move to Seconary..." default="False" execute="moveMany" />
 			<groupaction menu="Lock / Unlock Deck" default="False" execute="toggleLock" />
+			<groupaction menu="Draw Weakness" default="False" execute="drawWeakness" />
 		</group>
 		<group name="Discard Pile" visibility="all" ordered="True" width="63" height="88" icon="groups/discard.png" collapsed="False">
 			<groupaction menu="Shuffle All into Deck" default="True" execute="moveAllToPlayer" />
@@ -212,9 +214,6 @@
 		</group>
 		<group name="Setup" visibility="all" ordered="True" width="63" height="88" icon="groups/encounterS.png" collapsed="True">
 		</group>
-		<group name="Basic Weakness" visibility="none" ordered="True" width="63" height="88" icon="groups/player.png" collapsed="True">
-			<groupaction menu="Draw Random Weakness into Your Deck" default="True" execute="drawWeakness" />
-		</group>
 	</shared>
 	<deck>
 		<section name="Investigator" group="Hand" />
@@ -233,6 +232,5 @@
 		<section name="Second Special" group="2nd Special" />		
 		<section name="Chaos Bag" group="Chaos Bag" />
 		<section name="Setup" group="Setup" />
-		<section name="Basic Weakness" group="Basic Weakness" />
 	</sharedDeck>
 </game>


### PR DESCRIPTION
This is a spike on how I think the Random Basic Weakness drawing could be done. It sets up a separate Basic Weakness deck for the Core Set with a separate shared pile. There's a menu when right clicking to draw one into your deck.

There is one caveat, since we're autodrawing people's hands this step should happen first. People can just use the mulligan function from #16. We could also autodraw people's hands when they take a Mulligan with a confirm dialogue?

@GeckoTH you should probably double check I did this right and it has the right cards.
