### PR TITLE
revealing the next location puts it into the staging area

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -942,6 +942,9 @@ def addEncounter(group=None, x=0, y=0):
 def addEncounterSpecial(group=None, x=0, y=0):
     nextEncounter(specialDeck(), x, y, False)
 
+def addLocation(group=None, x=0, y=0):
+    nextLocation(locationDeck(), x, y)
+
 def addToStagingArea(card, facedown=False, who=me):
     #Check to see if there is already an encounter card here.
     #If so shuffle it left to make room
@@ -977,6 +980,25 @@ def nextEncounter(group, x, y, facedown, who=me):
     card.controller = who
     if len(group) == 0:
         resetEncounterDeck(group)
+
+def nextLocation(group, x, y, who=me):
+    mute()
+
+    if group.controller != me:
+        remoteCall(group.controller, "nextLocation", [group, x, y, me])
+        return
+
+    if len(group) == 0:
+        notify("No more location cards")
+        return
+
+    card = group.top()
+    if x == 0 and y == 0:  #Move to default position in the staging area
+        addToStagingArea(card, False, who)
+    else:
+        card.moveToTable(x-card.width()/2, y-card.height()/2, facedown)
+        notify("{} places '{}' on the table.".format(who, card))
+    card.controller = who
     
 def nextAgendaStage(group=None, x=0, y=0):
     mute()

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -177,7 +177,7 @@
 		</group>
 		<group name="Location" visibility="all" ordered="True" width="63" height="88" icon="groups/location.png" collapsed="False">
 			<groupaction menu="Shuffle" default="False" execute="shuffle" />
-			<groupaction menu="Reveal Next Location" default="True" execute="nextLocation" />
+			<groupaction menu="Reveal Next Location" default="True" execute="addLocation" />
 		</group>
 		<group name="Agenda Discard Pile" visibility="all" ordered="True" width="126" height="88" icon="groups/discard.png" collapsed="True" />
 		<group name="Act Discard Pile" visibility="all" ordered="True" width="126" height="88" icon="groups/discard2.png" collapsed="True" />


### PR DESCRIPTION
This adds locations into the "staging" area, where the encounter cards go. Both double clicking the location deck or right click "reveal next location" do the same thing.