### PR TITLE
Rework Basic Weaknesses

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -468,6 +468,15 @@ def deckLoaded(args):
     playerSetup(table, 0, 0, isPlayer, isShared)
     #if automate():         <-----Turning off Automation by default for ScriptVersion updates, but still want playerSetup to run
     #   playerSetup(table, 0, 0, isPlayer, isShared)
+
+def loadBasicWeaknesses(group, x = 0, y = 0):
+    if len(me.piles[BasicWeakness.PILE_NAME]) == 0:
+        bw = BasicWeakness(me)
+        bw.create_deck()
+        bw.shuffle()
+        notify("{} loaded Basic Weakness Deck".format(me))
+    else:
+        notify("{}'s Basic Weakness Deck already loaded.".format(me))
         
 #Triggered event OnChangeCounter
 # def counterChanged(player, counter, oldV): 

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1776,7 +1776,7 @@ def drawChaosToken(group, x = 0, y = 0):
     chaosBag().shuffle()
     drawPileToTable(chaosBag(), ChaosTokenX, ChaosTokenY)
 
-def drawWeakness(group, x = 0, y = 0):
+def drawBasicWeakness(group, x = 0, y = 0):
     mute()
 
     if len(me.piles[BasicWeakness.PILE_NAME]) == 0:

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1779,8 +1779,15 @@ def drawChaosToken(group, x = 0, y = 0):
 def drawWeakness(group, x = 0, y = 0):
     mute()
 
-    guid = BasicWeakness.draw()
-    card = me.deck.create(guid)
+    if len(me.piles[BasicWeakness.PILE_NAME]) == 0:
+        bw = BasicWeakness(me)
+        bw.create_deck()
+
+    bw_cards = me.piles[BasicWeakness.PILE_NAME]
+    bw_cards.shuffle()
+    card = bw_cards.top()
+    card.moveTo(me.deck)
+    # do we notify players of what the basic weakness card that was shuffled in?
     notify("{} shuffles a random Basic Weakness into deck".format(me))
     me.deck.shuffle()
 

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -159,6 +159,7 @@
 			<groupaction menu="Shuffle" execute="shuffle" />
 		</group>
 		<group name="Basic Weaknesses" visibility="none" width="63" height="88" icon="groups/player.png" collapsed="True">
+			<groupaction menu="Load Deck" execute="loadBasicWeaknesses" />
 			<groupaction menu="Shuffle" execute="shuffle" />
 		</group>
 	</player>

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -158,6 +158,9 @@
 		<group name="Sideboard" visibility="me" width="63" height="88" icon="groups/player-sideboard.png" collapsed="True">
 			<groupaction menu="Shuffle" execute="shuffle" />
 		</group>
+		<group name="Basic Weaknesses" visibility="me" width="63" height="88" icon="groups/player.png" collapsed="True">
+			<groupaction menu="Shuffle" execute="shuffle" />
+		</group>
 	</player>
 	<shared>
 		<counter name="VictoryPoints" default="0" reset="True" icon="counters/victory.png" />

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -144,7 +144,7 @@
 			<groupaction menu="Discard Many" default="False" execute="discardMany" />
 			<groupaction menu="Move to Seconary..." default="False" execute="moveMany" />
 			<groupaction menu="Lock / Unlock Deck" default="False" execute="toggleLock" />
-			<groupaction menu="Draw Weakness" default="False" execute="drawWeakness" />
+			<groupaction menu="Draw Basic Weakness" default="False" execute="drawBasicWeakness" />
 		</group>
 		<group name="Discard Pile" visibility="all" ordered="True" width="63" height="88" icon="groups/discard.png" collapsed="False">
 			<groupaction menu="Shuffle All into Deck" default="True" execute="moveAllToPlayer" />
@@ -158,7 +158,7 @@
 		<group name="Sideboard" visibility="me" width="63" height="88" icon="groups/player-sideboard.png" collapsed="True">
 			<groupaction menu="Shuffle" execute="shuffle" />
 		</group>
-		<group name="Basic Weaknesses" visibility="me" width="63" height="88" icon="groups/player.png" collapsed="True">
+		<group name="Basic Weaknesses" visibility="none" width="63" height="88" icon="groups/player.png" collapsed="True">
 			<groupaction menu="Shuffle" execute="shuffle" />
 		</group>
 	</player>


### PR DESCRIPTION
This reworks how basic weaknesses are handled based on the discord discussion yesterday:

* Created a player pile for holding the basic weaknesses that is collapsed by default.
* Draw Basic Weakness option from the player library will now first populate the new pile and draw from the top of it after shuffling
* There is a context menu for basic weakness for loading the deck
* Whenever the basic weakness deck is loaded, it'll scan the table (player owned), hand, deck, discard for the subtype "Basic Weakness" and remove those before creating the deck. This should prevent any dupes from entering play.

With these changes when needed a player can examine the Basic Weakness deck and pull the top card for a random draw or look through if a specific one one is needed.