### PR TITLE
Add section for holding special cards in deck.

### DIFF
--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -221,6 +221,7 @@
 	</shared>
 	<deck>
 		<section name="Investigator" group="Hand" />
+		<section name="Special" group="Discard Pile" />
 		<section name="Asset" group="Discard Pile" />
 		<section name="Event" group="Discard Pile" />
 		<section name="Skill" group="Discard Pile" />


### PR DESCRIPTION
This is for holding cards which don't count against the card limit, to simplify counting cards for the deck limit. Specifically to help when building decks with services like arkhamdb.com, where they keep cards that don't count against the player limit in separate sections.