### PR TITLE
highlight agenda card when hit doom level

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1059,6 +1059,14 @@ def subToken(card, tokenType):
     card.markers[tokenType] -= 1
     notify("{} removes a {} from '{}'".format(me, tokenType[0], card))
 
+def markerChanged(args):
+    card = args.card
+    if card.Type == "Agenda" and args.marker == Doom[0]:
+        if card.markers[Doom] >= int(card.properties[Doom[0]]):
+            card.highlight = EliminatedColour
+        else:
+            card.highlight = None
+
 def lockCard(card, x=0, y=0):
     mute()
     if isLocked(card):

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -39,6 +39,7 @@
 		<globalvariable name="playersSetup" value=""/>
 		<globalvariable name="currentPlayers" value="" />
 		<globalvariable name="done" value="" />
+		<globalvariable name="phase" value="" />
 		<globalvariable name="deckLocked" value="" />
 		<globalvariable name="firstPlayer" value="" />
 		<globalvariable name="activePlayer" value="" />

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -22,6 +22,7 @@
 		<event name="OnGameStarted" action="startOfGame"/>
 		<event name="OnDeckLoaded" action="deckLoaded"/>
 		<event name="OnGlobalVariableChanged" action="globalChanged"/>
+		<event name="OnMarkerChanged" action="markerChanged"/>
 	</events>
 	<fonts>
 		<font src="fonts/Calibri-Arkham.ttf" size="12" target="context" />


### PR DESCRIPTION
This highlights the agenda card when the doom level is greater or equal to the card's doom level. If the doom counter goes below, the highlight is removed. I'm using the color red for the highlight.

## TODO
- [x] count doom tokens for every card on the table for highlight
- [x] discard agenda cards when done
- [x] when advancing agenda, remove all doom tokens on the table