### PR TITLE
Set chaos token owner to drawing player.

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -499,12 +499,12 @@ def turnManagement():
     return auto == "Turn" or len(auto) == 0
 
 def createChaosBag(group, x=0, y=0):
-  for c in group:
-      if c.owner == me and c.model == "faa82643-1dda-4af7-96ad-298bc2d5b2dd":
-          c.moveToTable(x, y)
-          return
-  group.create("faa82643-1dda-4af7-96ad-298bc2d5b2dd", ChaosTokenX, ChaosTokenY, 1, False)
-
+    for c in group:
+        if c.owner == me and c.model == "faa82643-1dda-4af7-96ad-298bc2d5b2dd":
+            c.moveToTable(x, y)
+            return
+    bag = group.create("faa82643-1dda-4af7-96ad-298bc2d5b2dd", ChaosTokenX, ChaosTokenY, 1, False)
+    bag.highlight = me.color
 def flipCoin(group, x = 0, y = 0):
     mute()
     n = rnd(1, 2)
@@ -1395,6 +1395,7 @@ def drawPileToTable(player, group, x, y):
 
     card = group[0]
     card.moveToTable(x, y)
+    card.controller = player
     notify("{} draws {} from the {}.".format(player, card.name, group.name))
     return card
     


### PR DESCRIPTION
Set chaos token owner to drawing player. This way, the player who draws a chaos token can discard it. Also, I added a border to the Chaos Bag object, set to the player's color. For the moment, the only way I can see multiple users using the Chaos Bag object is for each player to have their own object. With the color borders, players will be able to know which is theirs.