### PR TITLE
Added placement for Campaign cards.

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -24,6 +24,8 @@ ActX = 262.5
 ActY = -222
 ScenarioX = 388.5
 ScenarioY = -234.75
+CampaignX = 500
+CampaignY = -234.75
 ChaosTokenX = 55
 ChaosTokenY = -231
 DoneColour = "#D8D8D8" # Grey
@@ -720,6 +722,8 @@ def agendaSetup(card):
         for c in setupDeck():
             if c.Type == "Scenario":
                 c.moveToTable(ScenarioX, ScenarioY)
+            elif c.Type == "Campaign":
+                c.moveToTable(CampaignX, CampaignY)
             elif i >= len(card.Setup) or card.Setup[i] == 't':
                 addToTable(c)
             elif card.Setup[i] == 's':

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -911,6 +911,8 @@ def defaultAction(card, x = 0, y = 0):
         discard(card, x, y)
     elif card.Type == "Mini": #Add action token
         addToken(card, Action)
+    elif card.Type == "Campaign": #Add a progress token
+        flipcard(card, x, y)
     else:
         exhaust(card, x, y)
         


### PR DESCRIPTION
These are used in POD expansions, and in the Strange Eons custom scenarios. This PR places campaign cards to the right of the agenda/act/scenario block when campaign cards are included in a scenario deck.