### PR TITLE
Adds ability to label phase changes in chat

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -767,6 +767,28 @@ def nextActStage(group=None, x=0, y=0):
 def nextAct(group = None, x = 0, y = 0):
     nextActStage(group, x, y)
 
+def advancePhase(group = None, x = 0, y = 0):
+    newPhase = num(getGlobalVariable("activePhase")) + 1
+    if newPhase > 4:
+        newPhase = 1
+    setGlobalVariable("activePhase", str(newPhase))
+    if newPhase == 1:
+        advanceTurn()
+        notify("{} advances phase to Mythos Phase".format(me))
+    elif newPhase == 2:
+        notify("{} advances phase to Investigator Phase".format(me))
+    elif newPhase == 3:
+        notify("{} advances phase to Enemy Phase".format(me))
+    elif newPhase == 4:
+        notify("{} advances phase to Upkeep Phase".format(me))
+        for player in getPlayers():
+            remoteCall(player, "doUpkeepPhase", [])
+    
+def advanceTurn():
+    newTurn = num(getGlobalVariable("activeTurn")) + 1
+    notify("{} advances to Turn '{}'".format(me, newTurn))
+    setGlobalVariable("activeTurn", str(newTurn))
+    
 def setAbilityCounters(investigatorCard):
     me.counters['Willpower'].value = num(investigatorCard.Willpower)
     me.counters['Intellect'].value = num(investigatorCard.Intellect)
@@ -799,7 +821,7 @@ def doUpkeepPhase():
     for card in table:
         if card.Type == "Investigator" and card.controller == me and not isLocked(card) and card.isFaceUp:
             addResource(card)
-        elif card.Type == "Mini":
+        elif card.Type == "Mini" and card.controller == me:
             card.markers[Action] = 0
 
     shared.counters['Round'].value += 1

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -41,6 +41,8 @@
 		<globalvariable name="deckLocked" value="" />
 		<globalvariable name="firstPlayer" value="" />
 		<globalvariable name="activePlayer" value="" />
+		<globalvariable name="activeTurn" value="1" />
+		<globalvariable name="activePhase" value="1" />
 	</globalvariables>
 	<card back="cards/card.jpg" front="cards/card.jpg" width="63" height="88" cornerRadius="4">
 		<property name="Unique" type="String" hidden="False" ignoreText="False" />
@@ -90,6 +92,7 @@
 		<groupaction menu="Clear Targets" default="False" shortcut="Esc" execute="clearTargets" />
 		
 		<groupactions menu="Automation">
+			<groupaction menu="Advance Phase" default="False" shortcut="F12" execute="advancePhase" />
 			<groupaction menu="Create Chaos Bag" default="False" execute="createChaosBag" />
 			<groupaction menu="Turn off Management" default="False" execute="automationOff" />
 			<groupaction menu="Enable Turn Management" default="False" execute="turnManagementOn" />


### PR DESCRIPTION
This adds ability to label phase changes in the log via the F12 key. This co-exists with the existing control-N upkeep trigger, although each serves a different purpose. This change will allow you to step through the phases, with a log entry for each step so that it's possible to review the log and determine what happened when. It also handles the upkeep trigger, so a user can choose which style of phase changes they prefer.