### PR TITLE
Fix path definitions. OCTGN insists on irrelevant properties for build.

### DIFF
--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -79,21 +79,21 @@
 		<size name="EncounterCard" width="63" height="88" back="cards/encounter.jpg" front="cards/encounter.jpg" cornerRadius="4"/>
 		<size name="MiniCard" width="40" height="63" back="cards/card.jpg" front="cards/card.jpg" cornerRadius="4" backWidth="40" backHeight="63" backCornerRadius="4" />
 		<size name="ChaosToken" width="40" height="40" back="cards/chaostokenback.jpg" front="cards/chaostokenback.jpg" cornerRadius="4" backWidth="40" backHeight="40" />
-	    <size name="LongPath" width="140" height="20" />
-	    <size name="MediumPath" width="70" height="20" />
-	    <size name="ShortPath" width="35" height="20" />
-	    <size name="ElbowPath" width="55" height="55" />
-	    <size name="CrossPath" width="90" height="90" />
-	    <size name="ThreeWayPath" width="85" height="85" />
-	    <size name="DirectionalMarker" width="20" height="20" />
-	    <size name="DiagConnectPath" width="60" height="60" />
-	    <size name="DiagLongPath" width="115" height="115" />
-	    <size name="DiagMediumPath" width="65" height="65" />
-	    <size name="DiagShortPath" width="38" height="38" />
-	    <size name="DiagElbowPath" width="77" height="77" />
-	    <size name="DiagCrossPath" width="74" height="74" />
-	    <size name="DiagThreeWayPath" width="76" height="76" />
-	    <size name="DiagDirectionalMarker" width="20" height="25" />
+	    <size name="LongPath" width="140" height="20" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="MediumPath" width="70" height="20" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="ShortPath" width="35" height="20" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="ElbowPath" width="55" height="55" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="CrossPath" width="90" height="90" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="ThreeWayPath" width="85" height="85" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DirectionalMarker" width="20" height="20" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagConnectPath" width="60" height="60" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagLongPath" width="115" height="115" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagMediumPath" width="65" height="65" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagShortPath" width="38" height="38" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagElbowPath" width="77" height="77" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagCrossPath" width="74" height="74" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagThreeWayPath" width="76" height="76" back="cards/card.jpg" front="cards/card.jpg" />
+	    <size name="DiagDirectionalMarker" width="20" height="25" back="cards/card.jpg" front="cards/card.jpg" />
 	</card>
 	<table name="Table" visibility="undefined" ordered="False" width="1150" height="536" board="background/tabletop.png" boardPosition="-575,-268,1150,536" background="background/background.jpg" backgroundStyle="uniformToFill">
 		<groupaction menu="Player Setup ..." default="False" shortcut="ctrl+shift+S" execute="playerSetup" />


### PR DESCRIPTION
OCTGN insists on irrelevant properties for build. I've added in defaults.