### PR TITLE
Locked and Anchored are not the same. Paths now check for both.

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -593,7 +593,7 @@ def doRestoreAll(group=table):
     myCards = (card for card in group
                 if card.controller == me)
     for card in myCards:
-        if not isLocked(card):
+        if not isLocked(card) and not card.anchor:
             card.orientation &= ~Rot90
     notify("{} readies all their cards.".format(me))
 


### PR DESCRIPTION
Paths were flipping during Upkeep. They are "anchored" not "locked" (since locked comes with a graphic). Now the upkeep checks for both.