### PR TITLE
add dunwich legacy basic weaknesses to basic weakness functions

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -435,10 +435,11 @@ def deckLoaded(args):
     #   playerSetup(table, 0, 0, isPlayer, isShared)
 
 def loadBasicWeaknesses(group, x = 0, y = 0):
-    if len(me.piles[BasicWeakness.PILE_NAME]) == 0:
+    basic_weakness_pile = me.piles[BasicWeakness.PILE_NAME]
+    if len(basic_weakness_pile) == 0:
         bw = BasicWeakness(me)
         bw.create_deck()
-        bw.shuffle()
+        basic_weakness_pile.shuffle()
         notify("{} loaded Basic Weakness Deck".format(me))
     else:
         notify("{}'s Basic Weakness Deck already loaded.".format(me))

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1484,17 +1484,14 @@ def drawXChaosTokens(player, group, x = 0, y = 0):
 def drawBasicWeakness(group, x = 0, y = 0):
     mute()
 
-    if len(me.piles[BasicWeakness.PILE_NAME]) == 0:
-        bw = BasicWeakness(me)
-        bw.create_deck()
+    loadBasicWeaknesses(group, x, y)
 
     bw_cards = me.piles[BasicWeakness.PILE_NAME]
     bw_cards_count = len(bw_cards)
     if (bw_cards_count == 0):
         notify("There are no Basic Weakness cards left!")
         return
-        
-    bw_cards.shuffle()
+
     card = bw_cards.top()
 
     return card

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -437,7 +437,13 @@ def deckLoaded(args):
 def loadBasicWeaknesses(group, x = 0, y = 0):
     basic_weakness_pile = me.piles[BasicWeakness.PILE_NAME]
     if len(basic_weakness_pile) == 0:
-        bw = BasicWeakness(me)
+        choice_list = ['all', 'core']
+        color_list = ['#0000FF', '#00FF00']
+        sets = askChoice("Which sets to load?", choice_list, color_list)
+        # load all sets if window is closed
+        if sets == 0:
+            sets = 1
+        bw = BasicWeakness(me, choice_list[sets - 1])
         bw.create_deck()
         basic_weakness_pile.shuffle()
         notify("{} loaded Basic Weakness Deck".format(me))

--- a/o8g/Scripts/basic_weakness.py
+++ b/o8g/Scripts/basic_weakness.py
@@ -11,6 +11,14 @@ class BasicWeakness:
             "22a5a1f6-cc50-47a9-9374-76204c97cf0a", # Mob Enforcer
             "9b1de9f2-b050-41c4-bfdc-16a40974a3fb", # Silver Twilight Acolyte
             "d5b68cab-54f1-488c-ba9f-68d8830cf2d0", # Stubborn Detective
+        ],
+        "dunwich_legacy": [
+            "1ecf4d84-da04-4c69-8fac-aa11bdc4171f", # 2x Indebted
+            "1ecf4d84-da04-4c69-8fac-aa11bdc4171f",
+            "ee9ed7fb-bd73-4a10-88ce-0617321ebecd", # 2x Internal Injury
+            "ee9ed7fb-bd73-4a10-88ce-0617321ebecd",
+            "bd089e8f-e3f0-4fd3-9bf2-e7de8832da73", # 2x Chronophobia
+            "bd089e8f-e3f0-4fd3-9bf2-e7de8832da73",
         ]
     }
     PILE_NAME = 'Basic Weaknesses'


### PR DESCRIPTION
This PR fixes and refactors some bugs with basic weakness loading. In addition, it also adds the dunwich legacy basic weaknesses so they can be easily used. Lastly, since there are multiple sets now in play, a dialogue asks what ones should be used.

![weakness](https://cloud.githubusercontent.com/assets/16457/23599442/be08e472-0206-11e7-8070-4aa846d536ae.PNG)
