### PR TITLE
Extra copy of Restricted Hall in MM

### DIFF
--- a/o8g/Decks/02 - Dunwich Legacy/2 - The Miskatonic Museum.o8d
+++ b/o8g/Decks/02 - Dunwich Legacy/2 - The Miskatonic Museum.o8d
@@ -33,7 +33,7 @@
     <card qty="1" id="0732ea89-f2f4-4fd6-8f85-a87f1858a38c">Exhibit Hall</card>
     <card qty="1" id="a2350979-4f5d-48a0-8056-9066aa360da3">Exhibit Hall</card>
     <card qty="1" id="1fee9788-f264-4754-82ce-8e324cc6e7d7">Exhibit Hall</card>
-    <card qty="1" id="a37f907d-30f4-405b-aaab-47e4786c9c71">Exhibit Hall</card>
+    <card qty="1" id="07d94c5f-3ce3-4e5d-9a30-a820d26edbad">Exhibit Hall</card>
   </section>
   <section name="Setup" shared="True">
     <card qty="1" id="f35868ff-263e-4a06-91d4-49fb17e22700">The Miskatonic Museum</card>


### PR DESCRIPTION
Addresses #114 
There was two copies of Exhibit Hall (Restricted Hall) - one in the Location deck, the other in the Setup deck. In addition there was no copy of Exhibit Hall (Athabaskan Exhibit). I replaced the Restricted Hall in the Location deck with the Athabaskan Exhibit.