### PR TITLE
Add sets & decks

### DIFF
--- a/o8g/Decks/05 - The Circle Undone/3 - The Secret Name.o8d
+++ b/o8g/Decks/05 - The Circle Undone/3 - The Secret Name.o8d
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Act" shared="True">
+    <card qty="1" id="8449d441-eb20-4b6c-94c5-3b9f3700d709">Investigating the Witch House</card>
+    <card qty="1" id="af8fda52-08c1-4706-98a2-85e9eb31bf4f">Beyond the Witch House</card>
+    <card qty="1" id="c6c424f9-f540-4369-9869-1946a55c30dd">Stopping the Ritual</card>
+  </section>
+  <section name="Agenda" shared="True">
+    <card qty="1" id="68d761f4-60ae-46cd-9f7a-824b13ee5a55">THE HERMIT · IX</card>
+    <card qty="1" id="4e77739e-b214-4a6b-b847-2a0817d7793f">The Familiar</card>
+    <card qty="1" id="b2ca1fb9-e670-45af-b273-deb03b848c4e">The Witch Light</card>
+    <card qty="1" id="53615356-f0c1-4cc2-9ba2-e1fffa146284">Marked for Sacrifice</card>
+  </section>
+  <section name="Location" shared="True">
+    <card qty="1" id="ef4104f5-64da-45f6-9e2a-bdf9be22949d">Unknown Places</card>
+    <card qty="1" id="f10e703a-742d-4814-a62c-c1125e48ece6">Unknown Places</card>
+    <card qty="1" id="2cd4a5aa-5ce5-4bc6-a9c3-99b526b566a9">Unknown Places</card>
+    <card qty="1" id="d96b9e82-4855-4dcc-9fed-e1bc6282a550">Unknown Places</card>
+    <card qty="1" id="859032e6-06fd-425d-884b-bca6585af5ae">Unknown Places</card>
+    <card qty="1" id="944e0e93-e42a-4eef-9d4e-9df72ec47061">Unknown Places</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="1" id="254213cb-2db4-4dd5-b74e-a2dee3b8d711">Brown Jenkin</card>
+    <card qty="2" id="5039b791-2c6c-444e-a866-fa11a6e4ed1e">Disquieting Dreams</card>
+    <card qty="2" id="95a1ad3a-5ef9-4fac-a751-cfa368756eca">Pulled by the Stars</card>
+    <card qty="2" id="06c8dd37-39da-4094-8e10-1b02fcc02030">Extradimensional Visions</card>
+    <card qty="3" id="553e10ea-a80c-435e-8db0-b2ddda222b60">Meddlesome Familiar</card>
+    <card qty="3" id="76a906b0-eea1-4ce1-9982-f7e0f1aab553">Swarm of Rats</card>
+    <card qty="3" id="39f45715-7bb8-4130-a4ab-e3e2aa9b09ae">Fate of All Fools</card>
+    <card qty="3" id="f8a088dc-787f-4b12-b4d9-6eb417547745">Terror in the Night</card>
+    <card qty="2" id="31b852a4-8199-4e3e-a062-e0624b954bfa">Shapes in the Mist</card>
+    <card qty="2" id="9e1a0a3f-b47d-463b-852f-af0b39557984">Realm of Torment</card>
+    <card qty="3" id="eddfac33-2e84-4de0-94cf-1e8a66dceefe">Centuries of Secrets</card>
+    <card qty="2" id="6b25fd79-437b-4ce0-8405-82e9c2d541be">Evil Past</card>
+    <card qty="2" id="90cb11ac-0ded-48c0-9323-d3b3df0bff11">Bedeviled</card>
+    <card qty="2" id="bfbfda7f-1527-4564-a3bc-3660f5890596">Wracked</card>
+    <card qty="3" id="a964717e-3126-4ff0-9eb5-d1e7884ee538">Diabolic Voices</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="54164db4-ac3b-4b32-92a3-2847729fb7df">Moldy Halls</card>
+    <card qty="1" id="b89c14d2-c0bb-4e99-9c9d-1ba0aff7b2bd">Walter Gilman’s Room</card>
+    <card qty="1" id="240f4107-e6d9-4820-91d3-7365cc40407c">Decrepit Door</card>
+    <card qty="1" id="af26112b-c8d8-48e3-9e36-f6aae87f568e">Decrepit Door</card>
+    <card qty="1" id="fcb27e66-5c77-4edf-b418-e0b205add86f">Decrepit Door</card>
+    <card qty="1" id="33254ae5-0821-43db-95ba-66c661c2307f">Unknown Places</card>
+    <card qty="1" id="9c363593-d0df-48a1-a904-9c6ebdc8281b">The Black Book</card>
+    <card qty="1" id="33bfb887-f781-43f9-a8a5-4677f811ca24">The Secret Name</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="1" id="809ab85e-3f52-414a-876b-7af4a4e53749">Nahab</card>
+    <card qty="1" id="8293e074-4c6b-4477-8630-eb47ef585150">Site of the Sacrifice</card>
+    <card qty="1" id="e9721e11-b617-4b4b-a37d-18c1e3028f9e">Keziah’s Room</card>
+    <card qty="2" id="c63d6de9-9ae0-4cfb-a561-b0b2e58dffb7">Strange Geometry</card>
+    <card qty="2" id="5bc1ba5c-2aa1-469f-abc0-977b3014866e">Ghostly Presence</card>
+  </section>
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Second Special" shared="True" />
+  <section name="Chaos Bag" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/05 - The Circle Undone/4 - The Wages of Sin.o8d
+++ b/o8g/Decks/05 - The Circle Undone/4 - The Wages of Sin.o8d
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Act" shared="True">
+    <card qty="1" id="f7a92c70-67d6-413e-8e02-28503af28dfa">In Pursuit of the Dead</card>
+    <card qty="1" id="9248442d-eacd-4813-9bb2-142b4fd7dd27">In Pursuit of the Living</card>
+  </section>
+  <section name="Agenda" shared="True">
+    <card qty="1" id="c649bd6a-77f3-4ef1-8dfc-b20c0a034702">THE HANGED MAN · XII</card>
+    <card qty="1" id="ef33243d-ba84-495f-9eb8-2efc9e1a98f5">Death’s Approach</card>
+  </section>
+  <section name="Location" shared="True">
+    <card qty="2" id="fe1d32d4-ba8e-49ae-b0a4-58b4a207c453">Bane of the Living</card>
+    <card qty="2" id="6709f629-17f6-42bf-aa4a-f106840e8ae9">Burdens of the Past</card>
+    <card qty="2" id="1dafb518-3669-4a12-8f27-6b0a6335227f">Malevolent Spirit</card>
+    <card qty="3" id="39f45715-7bb8-4130-a4ab-e3e2aa9b09ae">Fate of All Fools</card>
+    <card qty="3" id="f8a088dc-787f-4b12-b4d9-6eb417547745">Terror in the Night</card>
+    <card qty="2" id="31b852a4-8199-4e3e-a062-e0624b954bfa">Shapes in the Mist</card>
+    <card qty="2" id="9e1a0a3f-b47d-463b-852f-af0b39557984">Realm of Torment</card>
+    <card qty="2" id="2abaf9f5-7308-436e-8c2e-de4aa74df0cf">Trapped Spirits</card>
+    <card qty="2" id="57197e20-ec0a-4383-bc8c-6c60a2a37e0b">Wraith</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="2" id="1529b14f-ab18-4db9-841a-b0b603f1efde">Grave-light</card>
+    <card qty="2" id="288969bc-3df6-431e-b04d-f0d150af3be4">Ominous Portents</card>
+    <card qty="2" id="051bcbce-880a-4a89-a41c-48e6dc451815">Punishment</card>
+    <card qty="2" id="ff76e088-1395-4e10-8a43-17de4c914049">Vengeful Witch</card>
+    <card qty="3" id="eddfac33-2e84-4de0-94cf-1e8a66dceefe">Centuries of Secrets</card>
+    <card qty="2" id="6b25fd79-437b-4ce0-8405-82e9c2d541be">Evil Past</card>
+    <card qty="2" id="90cb11ac-0ded-48c0-9323-d3b3df0bff11">Bedeviled</card>
+    <card qty="2" id="bfbfda7f-1527-4564-a3bc-3660f5890596">Wracked</card>
+    <card qty="3" id="a964717e-3126-4ff0-9eb5-d1e7884ee538">Diabolic Voices</card>
+    <card qty="1" id="8d15e313-41f9-4e94-92a2-f62aafb96742">Priestess of the Coven</card>
+    <card qty="3" id="501730c1-6f1a-47c3-9683-719bff03ca76">Coven Initiate</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="a263c7a7-7641-479b-bb07-926c93371e15">The Wages of Sin</card>
+    <card qty="1" id="ea209a3c-ba80-469e-9966-f01d35a550d1">Chapel Attic</card>
+    <card qty="1" id="8b5a93f4-6782-4263-92cd-0c141e6ffb7d">Chapel Attic</card>
+    <card qty="1" id="949842f1-b1f1-46da-8656-0357e77df332">Chapel Crypt</card>
+    <card qty="1" id="4adf6b60-a149-458e-b677-fb9c1662d719">Chapel Crypt</card>
+    <card qty="1" id="d54acf40-23db-4210-bd8d-a1aa9ee84ad1">Heretics’ Graves</card>
+    <card qty="1" id="68d6765d-2d4d-4882-be2a-9d569ef2e662">Heretics’ Graves</card>
+    <card qty="1" id="028d377a-a1ad-44ee-91f7-ee1baa5210c2">The Gallows</card>
+    <card qty="1" id="e22800b9-b238-4887-8289-35cf0c978363">The Gallows</card>
+    <card qty="1" id="05e49566-9511-43e5-8304-41754b33a5ca">Abandoned Chapel</card>
+    <card qty="1" id="f4971a44-74c0-430f-9d84-374ca224ca57">Haunted Fields</card>
+    <card qty="1" id="3353c57b-4def-4ddb-93bc-5c58ec8be27c">Hangman’s Brook</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="4" id="11b99268-8d50-4863-9b24-7aa2f2f3f0ef">Spectral Web</card>
+    <card qty="2" id="6b11ef39-6fc6-4c90-b96b-7f32a6ca8b6b">Watcher's Grasp</card>
+    <card qty="1" id="5c226792-755e-4ad3-b74b-f42864cda61b">The Spectral Watcher</card>
+  </section>
+  <section name="Second Special" shared="True">
+    <card qty="1" id="c2e303a2-88fa-40b4-aba3-eeb7f65f136f">Heretic</card>
+    <card qty="1" id="2db09a66-5db7-4e52-8e91-0eed039312cb">Heretic</card>
+    <card qty="1" id="b1b9b253-81ec-4429-85f3-44641924844d">Heretic</card>
+    <card qty="1" id="692f82a8-3fdb-4bb0-b4e4-4cb738482978">Heretic</card>
+    <card qty="1" id="b3ca52b8-7d20-4f74-a57d-0b65edd6d610">Heretic</card>
+    <card qty="1" id="2b3aadab-97d4-4ea9-91a5-bd40534805f9">Heretic</card>
+  </section>
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Chaos Bag" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/05 - The Circle Undone/5 - For the Greater Good.o8d
+++ b/o8g/Decks/05 - The Circle Undone/5 - For the Greater Good.o8d
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Agenda" shared="True">
+    <card qty="1" id="c558324e-609c-4490-9b1a-e8bd88ddba00">THE HIEROPHANT · V</card>
+    <card qty="1" id="28df5d40-3637-4ddc-a344-5a7ffd499bbe">Ends and Means</card>
+  </section>
+  <section name="Act" shared="True">
+    <card qty="1" id="4d17a25d-481f-4223-b994-611ad03f18c4">Warm Welcome</card>
+    <card qty="1" id="39f80193-d3b1-4137-a14e-cae707519bb3">Infiltrating the Lodge</card>
+    <card qty="1" id="0bdfd6d5-3f5f-458a-99ae-208ae010afcb">Obtaining the Device</card>
+    <card qty="1" id="c458c425-9802-44fa-8ee0-fd42381d42af">The Four Keys</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="1" id="093c9a1a-a87d-4cdc-8832-824be87b0f07">Call to Order</card>
+    <card qty="1" id="d2c08b5e-afe7-44b3-81ab-26ec0866d3d3">Expulsion</card>
+    <card qty="2" id="d0d83800-414d-4913-b66f-78b9f8dce82c">Beneath the Lodge</card>
+    <card qty="2" id="16a55402-d8cc-4d8a-ac73-11301f6ec9c3">Mark of the Order</card>
+    <card qty="2" id="edbb082b-fdd8-42de-a328-fcd65398e1fc">Evil Past</card>
+    <card qty="3" id="c082467f-92dd-493c-a00a-026c26e133f5">Centuries of Secrets</card>
+    <card qty="2" id="779ed398-8619-4fa1-bd77-8b7be2c44c75">Mysteries of the Lodge</card>
+    <card qty="3" id="2f2f179f-dbbc-4bfc-85cc-b67e1bd7aa9a">Ancient Evils</card>
+    <card qty="2" id="64d5c48c-02fb-48ac-b3ea-086a20721d69">Mysterious Chanting</card>
+    <card qty="2" id="dc0e7a80-2902-4760-8eeb-2ddb6fe8ee93">Locked Door</card>
+  </section>
+  <section name="Location" shared="True">
+    <card qty="1" id="64ed2a25-81dd-4889-9b41-f25796cdb361">Vault</card>
+    <card qty="1" id="d1b5a0e2-82df-4b8e-b96d-67c5f446c986">Library</card>
+    <card qty="1" id="d54c32cd-45e6-4bf2-b4cf-66769783ec78">Sanctum Doorway</card>
+    <card qty="1" id="9aecb0e7-3275-425b-95f8-99be1a99621d">Sanctum Doorway</card>
+    <card qty="1" id="769f425e-cbbe-4f6d-97d4-85780c69730a">Inner Sanctum</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="3" id="8d7edcd9-63e0-4d2f-b8a1-c1e7cbf11c7a">Acolyte</card>
+    <card qty="1" id="5287d028-b018-45ec-b63c-553262c4cb8b">Wizard of the Order</card>
+    <card qty="2" id="f4eb7915-243a-48e4-9aef-a0397687f600">Knight of the Inner Circle</card>
+    <card qty="1" id="d8483e0d-5b23-4214-97c1-dbc4249c384a">Cell Keeper</card>
+  </section>
+  <section name="Second Special" shared="True">
+    <card qty="3" id="2cfe6d4e-1ded-4217-be8f-f30c4989f16f">Lodge Neophyte</card>
+    <card qty="1" id="569ae12f-4a94-49f5-8cbd-3104502c13c6">Keeper of Secrets</card>
+    <card qty="2" id="f526eda8-9504-45d8-a710-f7b3279119fc">Knight of the Outer Void</card>
+    <card qty="1" id="781b618f-5555-4688-be9f-2f37e40dde5b">Lodge Jailor</card>
+  </section>
+  <section name="Chaos Bag" shared="True" />
+  <section name="Setup" shared="True">
+    <card qty="1" id="37bb6382-1e06-43f8-98c1-9f4c46eae6ae">For the Greater Good</card>
+    <card qty="1" id="2cb4bbdf-869a-41a2-9e07-8f56caafbc56">Lodge Gates</card>
+    <card qty="1" id="941b7c4c-d30e-4ebe-b530-c4f740db0814">Lobby</card>
+    <card qty="1" id="678f12f3-b7cb-4afe-96cb-fc5e29bcfeb9">Lodge Cellar</card>
+    <card qty="1" id="a272bb4a-f6e3-4d08-9db7-ba0c2c79a9e0">Lodge Gates</card>
+    <card qty="1" id="28fd06e0-798c-4be0-99c8-2484938f4acf">Lobby</card>
+    <card qty="1" id="29c9979d-08c7-4b46-8f4d-3882710b4dac">Lodge Cellar</card>
+    <card qty="1" id="d31e3e02-9b3b-476e-b37f-80a80480c6bd">Lounge</card>
+    <card qty="1" id="0c55379a-9551-4b0b-a26e-dee84a2f4723">Lodge Catacombs</card>
+    <card qty="1" id="c9ff7c61-70ef-4cf3-8776-41c5f2550c7b">Puzzle Box</card>
+    <card qty="1" id="91f8f06a-b8f8-4a6e-ab6b-3a42236d3d28">Summoned Beast</card>
+    <card qty="1" id="5244c3f2-2039-4f6d-a49d-a00eb4c9b370">August Lindquist</card>
+    <card qty="1" id="d060ab82-c7c4-4154-b76a-e1f881a01159">Nathan Wick</card>
+    <card qty="1" id="49d18b2f-a191-4569-9ce4-06a5bdd33bf6">Skull</card>
+    <card qty="1" id="f1f63047-e572-4f15-aee7-1aaca33a63ed">Cultist</card>
+    <card qty="1" id="eb0dc92b-654a-41a3-8e06-7053d8c94f22">Tablet</card>
+    <card qty="1" id="ae10abfc-abb1-41c7-9490-b3f91d8574b2">Elder One</card>
+  </section>
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/05 - The Circle Undone/6 - Union and Disillusion.o8d
+++ b/o8g/Decks/05 - The Circle Undone/6 - Union and Disillusion.o8d
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Agenda" shared="True">
+    <card qty="1" id="0a42e490-8234-4f13-a2ed-3275b2d82325">THE LOVERS · VI</card>
+    <card qty="1" id="c728e562-199b-4f9e-a54e-c2ff2f7f3088">Crossroads of Fate</card>
+  </section>
+  <section name="Act" shared="True">
+    <card qty="1" id="b0e80ad3-fea9-4b02-a1ca-921f1da17b65">The Unvisited Isle</card>
+    <card qty="1" id="6127d4b4-147e-446d-95d1-11668ff3a8c7">Fated Souls</card>
+    <card qty="1" id="6ebfafbe-e588-48eb-9bfc-d5f99517a92b">Beyond the Mist (v. I)</card>
+    <card qty="1" id="efbe7666-ffae-44dd-9958-893a2ec90d4d">Beyond the Mist (v. II)</card>
+    <card qty="1" id="f0a7e46e-0754-4068-b868-a01fc790d039">Beyond the Mist (v. III)</card>
+    <card qty="1" id="e6eb679c-e554-4acd-a1b2-f1982e7e07b5">Beyond the Mist (v. IV)</card>
+    <card qty="1" id="06128107-071b-474e-9fa4-4b3ecb427fe8">The Binding Rite</card>
+    <card qty="1" id="624f440a-ecc7-47ff-9e67-8d9e33e938a0">The Broken Rite</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="3" id="626b2e7c-3dee-4522-b7bf-f5ac7c6bacab">Whippoorwill</card>
+    <card qty="2" id="13df574f-7ccd-470b-898c-5c50db2e60eb">Spectral Raven</card>
+    <card qty="2" id="260173d9-6c32-4a75-8844-eca23ffcec2b">Eager for Death</card>
+    <card qty="2" id="2c683365-691b-41f5-964a-65f41cd8314b">Psychopomp’s Song</card>
+    <card qty="2" id="0e75ebaa-4ace-49df-ab40-8c629d920efe">Death Approaches</card>
+    <card qty="2" id="4600ec24-0ac5-412b-a50e-dc0618a76276">Marked for Death</card>
+    <card qty="3" id="2fc27237-5a64-4e53-9490-8e2f24a86465">Terror in the Night</card>
+    <card qty="3" id="69fba3d3-9218-40c4-9f72-9d428de08a30">Fate of All Fools</card>
+    <card qty="2" id="7b980f47-dc9b-4ca5-9362-f8d967d6b0fa">Realm of Torment</card>
+    <card qty="2" id="766e1693-b1eb-4590-954b-2e18072e18f9">Shapes in the Mist</card>
+    <card qty="1" id="f7c74c76-84b8-4f5b-8cd8-a5e68cc0410b">Nether Mist</card>
+    <card qty="2" id="4ded3644-33e3-42cb-9465-65905d322cc1">Shadow Hound</card>
+    <card qty="2" id="3f445c62-94aa-4015-a1cb-700977b6b023">Whispers in the Dark</card>
+    <card qty="3" id="2f2f179f-dbbc-4bfc-85cc-b67e1bd7aa9a">Ancient Evils</card>
+    <card qty="2" id="457be9d8-fdd3-4319-86eb-de9d07a5e572">Crypt Chill</card>
+    <card qty="2" id="91a7fccc-8260-413c-b181-48f04ef58b99">Obscuring Fog</card>
+  </section>
+  <section name="Location" shared="True">
+    <card qty="1" id="d4c52940-3935-4434-b9ef-42085bb8972b">Unvisited Isle</card>
+    <card qty="1" id="d5f6facc-cbb7-4043-9bc9-206a894d9570">Unvisited Isle</card>
+    <card qty="1" id="9863cb4c-7c67-4840-8136-7361dd98069e">Unvisited Isle</card>
+    <card qty="1" id="5811057e-efb5-49c1-9219-8c4175f747ef">Unvisited Isle</card>
+    <card qty="1" id="0d528e4a-be44-4fb3-b1ac-a85b0c78be19">Unvisited Isle</card>
+    <card qty="1" id="366502f7-2985-49ad-a6a2-495afb3a390b">Unvisited Isle</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="3" id="343b9330-c6b0-4ad3-90b0-aef7cab1ba12">Coven Initiate</card>
+    <card qty="1" id="6348e5e1-57f3-4f44-90f0-d3593e3c43ec">Priestess of the Coven</card>
+    <card qty="3" id="2cfe6d4e-1ded-4217-be8f-f30c4989f16f">Lodge Neophyte</card>
+    <card qty="1" id="569ae12f-4a94-49f5-8cbd-3104502c13c6">Keeper of Secrets</card>
+    <card qty="2" id="779ed398-8619-4fa1-bd77-8b7be2c44c75">Mysteries of the Lodge</card>
+    <card qty="1" id="f22407c7-4f91-44b6-9382-e889c4741131">The Spectral Watcher</card>
+    <card qty="2" id="3b041a9e-6978-46a6-bcef-a35f30ef7b7b">Watcher's Grasp</card>
+  </section>
+  <section name="Second Special" shared="True">
+    <card qty="1" id="c734e8ac-f666-4427-8bb8-59442a47ad50">Gavriella Mizrah</card>
+    <card qty="1" id="e89cab8c-6f2f-40b2-aec4-ac7bd1462c6c">Gavriella’s Fate</card>
+    <card qty="1" id="5303ae39-304b-40d4-a513-a669bcec20aa">Jerome Davids</card>
+    <card qty="1" id="caf24cd0-edec-48b7-b767-ef6f1af97b99">Jerome’s Fate</card>
+    <card qty="1" id="7acf3471-3b4d-4ee4-baba-0b51229a1f13">Penny White</card>
+    <card qty="1" id="70d9976e-4cdd-4d39-a298-482d315be13f">Penny’s Fate</card>
+    <card qty="1" id="b065e1a1-9612-45e3-a4e8-65105751b892">Valentino Rivas</card>
+    <card qty="1" id="4270635a-1270-4d7e-a83f-f76e00becc10">Valentino’s Fate</card>
+  </section>
+  <section name="Chaos Bag" shared="True" />
+  <section name="Setup" shared="True">
+    <card qty="1" id="1585647b-56d3-4856-bd37-76fde6b807c7">Union and Disillusion</card>
+    <card qty="1" id="8c5e3281-80a0-41f0-9d38-7f988383ad80">Miskatonic River</card>
+    <card qty="1" id="301ef491-7012-41b0-8c48-d8747541cb4a">Forbidding Shore</card>
+    <card qty="1" id="2cf802b6-d0e0-4bb1-965a-2b61ef455515">The Geist-Trap</card>
+    <card qty="1" id="0932a14c-516b-40b2-a5ed-c3096388ac35">Watcher’s Gaze</card>
+    <card qty="1" id="f3071036-a8cf-4cae-b4d2-435dd7d125b8">Anette Mason</card>
+    <card qty="1" id="da12b973-ace4-4dbc-ae3d-4bb3b3e0cf1c">Josef Meiger</card>
+  </section>
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/05 - The Circle Undone/7 - In the Clutches of Chaos.o8d
+++ b/o8g/Decks/05 - The Circle Undone/7 - In the Clutches of Chaos.o8d
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Agenda" shared="True">
+    <card qty="1" id="e786c226-d4d7-48ff-a80a-4775a939dd91">THE CHARIOT · VII</card>
+  </section>
+  <section name="Act" shared="True">
+    <card qty="1" id="d8c145e0-aef1-4e62-a68d-4d2cc1dd16f9">Dark Knowledge (v. I)</card>
+    <card qty="1" id="8f329d22-5e4c-4be6-9779-4f24f80159c7">Beyond the Grave</card>
+    <card qty="1" id="d200f45b-a3d2-4590-8117-6608ecb996eb">Dark Knowledge (v. II)</card>
+    <card qty="1" id="106a08d0-4732-4568-a864-c7c30752fe02">New World Order</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="3" id="e69a16e5-2d20-4f88-8691-9cf21ac05fb7">Chaos Manifest</card>
+    <card qty="2" id="2e096aff-2f1f-4590-92f3-0a0766d4fde0">Primordial Gateway</card>
+    <card qty="3" id="bb227dd9-c7cc-4b63-8479-1c16de046539">Terror Unleashed</card>
+    <card qty="3" id="f13a2462-7466-4b9d-b000-5e2d8c4af564">Daemonic Piping</card>
+    <card qty="2" id="76a0d01f-3487-41d5-8bff-560ab33dd6f4">Hunting Nightgaunt</card>
+    <card qty="2" id="ea64a8ea-b5e7-42a3-9763-a9b9048055ec">On Wings of Darkness</card>
+  </section>
+  <section name="Location" shared="True" />
+  <section name="Special" shared="True">
+    <card qty="2" id="007690be-09a3-42ae-a691-a85543ffedb9">Witness of Chaos</card>
+    <card qty="2" id="dbe9eddf-d8f7-4f76-855a-44393619cea1">Toil and Trouble</card>
+    <card qty="3" id="343b9330-c6b0-4ad3-90b0-aef7cab1ba12">Coven Initiate</card>
+    <card qty="1" id="6348e5e1-57f3-4f44-90f0-d3593e3c43ec">Priestess of the Coven</card>
+    <card qty="2" id="edbb082b-fdd8-42de-a328-fcd65398e1fc">Evil Past</card>
+    <card qty="3" id="c082467f-92dd-493c-a00a-026c26e133f5">Centuries of Secrets</card>
+    <card qty="3" id="a0ebb0e6-91c1-4839-be28-3410d18e47c0">Diabolic Voices</card>
+    <card qty="2" id="e008057c-20cd-4508-bfd0-457fe32ad15f">Wracked</card>
+    <card qty="2" id="e3d19014-ace7-4ea4-8e05-57f33692dd9a">Bedeviled</card>
+  </section>
+  <section name="Second Special" shared="True">
+    <card qty="2" id="2809f893-3aa8-468a-943a-372bef4f909b">Lodge Enforcer</card>
+    <card qty="2" id="e822c46c-76de-4827-8fd5-b84400c8b212">Secrets of the Beyond</card>
+    <card qty="3" id="2cfe6d4e-1ded-4217-be8f-f30c4989f16f">Lodge Neophyte</card>
+    <card qty="1" id="569ae12f-4a94-49f5-8cbd-3104502c13c6">Keeper of Secrets</card>
+    <card qty="2" id="779ed398-8619-4fa1-bd77-8b7be2c44c75">Mysteries of the Lodge</card>
+    <card qty="3" id="d411e61d-9f83-49cb-bc13-d5d6b5c58336">Rotting Remains</card>
+    <card qty="2" id="569bb661-9875-4e36-a23e-a865df3fca21">Frozen in Fear</card>
+    <card qty="2" id="27eb17a3-e8ae-4c44-9f56-1018e6047d67">Dissonant Voices</card>
+    <card qty="3" id="f070e39a-2517-4899-a42d-829b2a9ebf2a">Hunting Shadow</card>
+    <card qty="2" id="65a0cf6c-89e4-4e20-948d-5668de15bd9c">False Lead</card>
+  </section>
+  <section name="Chaos Bag" shared="True" />
+  <section name="Setup" shared="True">
+    <card qty="1" id="af187725-013f-47b5-8f23-36439c776663">In the Clutches of Chaos</card>
+    <card qty="1" id="5b1b97df-7bc1-42e8-aa55-c45ab8e4129d">French Hill</card>
+    <card qty="1" id="96e24b77-d561-4726-a36a-fdc0c8d14cea">French Hill</card>
+    <card qty="1" id="a98aea8f-073e-41e0-a739-78599ece71b2">Rivertown</card>
+    <card qty="1" id="4c511cf5-07d3-4c4a-94ac-f3b392d863b8">Rivertown</card>
+    <card qty="1" id="939cecea-c846-4ffd-bb1b-39e848b75710">Southside</card>
+    <card qty="1" id="af069455-dd28-47ba-9e14-0c559695332b">Southside</card>
+    <card qty="1" id="e8f91327-fe0a-4a84-b953-2e78bef56ac0">Uptown</card>
+    <card qty="1" id="73b8bb44-802b-47ec-9bb8-ec31836671e7">Uptown</card>
+    <card qty="1" id="c2bb0fb9-fa46-4f7b-b33d-c0c0776050b8">South Church</card>
+    <card qty="1" id="94a14d03-9193-4f51-99dc-b08f8817d33c">South Church</card>
+    <card qty="1" id="140e4849-4849-4cb8-9888-0d7647da8a50">Merchant District</card>
+    <card qty="1" id="8fc7e31e-9a02-4896-8c98-7f7202bbd4ee">Merchant District</card>
+    <card qty="1" id="57b76424-5b5f-4a7d-b256-4e057055bdf5">Hangman’s Hill</card>
+    <card qty="1" id="2cc3aacd-9eb4-4c88-92a8-f421a5477ef3">Silver Twilight Lodge</card>
+    <card qty="1" id="b03f1a0d-3025-410c-861f-8524f860fc3c">Hangman’s Hill</card>
+    <card qty="1" id="954fe8ed-0104-4621-903f-f56ac91c961a">Silver Twilight Lodge</card>
+    <card qty="1" id="dec4454d-05ef-49ca-8915-39429b037eea">Piper of Azathoth</card>
+  </section>
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/05 - The Circle Undone/8 - Before the Black Throne.o8d
+++ b/o8g/Decks/05 - The Circle Undone/8 - Before the Black Throne.o8d
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Agenda" shared="True">
+    <card qty="1" id="1243ebf8-6f47-466c-9202-7534c9fc1a34">WHEEL OF FORTUNE · X</card>
+    <card qty="1" id="cb7c6a83-05c2-4210-a1e7-9130b806ab72">It Awaits</card>
+    <card qty="1" id="a1a82dd1-3db2-4ebd-b73c-b54f43e7e4a4">The Final Countdown</card>
+  </section>
+  <section name="Act" shared="True">
+    <card qty="1" id="c2141986-a61d-46b3-a857-aa7183990531">The Cosmos Beckons</card>
+    <card qty="1" id="1fc155f2-323e-4418-9e4c-a970adc5d44f">In Azathoth’s Domain</card>
+    <card qty="1" id="98ed9247-476e-4821-91b0-962429d6cacd">What Must Be Done</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="3" id="f82c2ee2-3061-4484-ae50-6afb13144588">Mindless Dancer</card>
+    <card qty="3" id="280f5c41-3ae0-462d-9a67-e46c8cf02d62">Ultimate Chaos</card>
+    <card qty="2" id="d56e90f0-5778-4f3d-8648-7736f402dbe3">Whispered Bargain</card>
+    <card qty="2" id="d4ae91ab-d75b-4931-8315-3ab491184cc4">The End is Nigh!</card>
+    <card qty="2" id="f5245cce-527b-4ea8-9394-f8a45cea9ea1">A World in Darkness</card>
+    <card qty="3" id="f13a2462-7466-4b9d-b000-5e2d8c4af564">Daemonic Piping</card>
+    <card qty="3" id="2fc27237-5a64-4e53-9490-8e2f24a86465">Terror in the Night</card>
+    <card qty="3" id="69fba3d3-9218-40c4-9f72-9d428de08a30">Fate of All Fools</card>
+    <card qty="3" id="2f2f179f-dbbc-4bfc-85cc-b67e1bd7aa9a">Ancient Evils</card>
+    <card qty="3" id="8d7edcd9-63e0-4d2f-b8a1-c1e7cbf11c7a">Acolyte</card>
+    <card qty="1" id="5287d028-b018-45ec-b63c-553262c4cb8b">Wizard of the Order</card>
+    <card qty="2" id="64d5c48c-02fb-48ac-b3ea-086a20721d69">Mysterious Chanting</card>
+  </section>
+  <section name="Location" shared="True">
+    <card qty="3" id="b728dcad-e66e-4868-a8b3-059f2c7ec47f">Cosmos</card>
+    <card qty="3" id="b3f94eaf-7b7b-4c71-971e-e0f85bf4a276">Cosmos</card>
+    <card qty="3" id="0bea9f77-2890-455b-857f-a36659f40ef8">Cosmos</card>
+    <card qty="1" id="12b495bf-d262-4462-85b3-baf8388c23fb">Cosmos</card>
+    <card qty="2" id="f0883c1c-1ad2-46b9-bd87-1d3d5cd8f342">Cosmos</card>
+  </section>
+  <section name="Special" shared="True" />
+  <section name="Second Special" shared="True" />
+  <section name="Chaos Bag" shared="True" />
+  <section name="Setup" shared="True">
+    <card qty="1" id="6febb6ad-ef14-4445-8bc7-717919cc26b8">Before the Black Throne</card>
+    <card qty="1" id="fd8a0dd1-5c6f-423c-9bf9-8c65f9fa9532">Cosmic Ingress</card>
+    <card qty="1" id="8474e4b7-2f14-4a5f-811e-32a24106eb6c">Cosmos</card>
+    <card qty="1" id="bd10b235-6a1c-4744-91ff-e2684507e0ee">Cosmos</card>
+    <card qty="1" id="a02f9ddf-b3f2-45d8-9717-4097857ac31c">Cosmos</card>
+    <card qty="1" id="dec4454d-05ef-49ca-8915-39429b037eea">Piper of Azathoth</card>
+    <card qty="1" id="ab2ec5e1-6170-410a-a5b2-767dbfa02f17">Azathoth</card>
+  </section>
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/05 - The Circle Undone/Prologue - Gavriella Mizrah.o8d
+++ b/o8g/Decks/05 - The Circle Undone/Prologue - Gavriella Mizrah.o8d
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf" sleeveid="0">
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
   <section name="Investigator" shared="False">
     <card qty="1" id="ba64216c-8dfa-4aec-97d3-6b1e4720331e">Gavriella Mizrah</card>
     <card qty="1" id="32851c70-7805-46c9-bd17-47b70f323441">Gavriella Mizrah</card>
   </section>
-  <section name="Special" shared="False" />
   <section name="Asset" shared="False">
     <card qty="1" id="1eddd4eb-0221-4570-b4fc-15700c192a91">First Aid</card>
+    <card qty="1" id="97278962-9d51-44ab-92d9-b8307da166ea">Physical Training</card>
+    <card qty="1" id="65f0cf81-c907-4d8d-b05a-4f4f610056ee">.45 Automatic</card>
     <card qty="1" id="8fb609a2-6736-4b0a-aecb-fa32ad80694d">Guard Dog</card>
   </section>
   <section name="Event" shared="False">
@@ -15,12 +16,10 @@
     <card qty="1" id="a3c5e4b0-dd97-4cba-addc-51b70e68dd32">Extra Ammunition</card>
     <card qty="2" id="e6c87818-e603-49c0-8f09-0c7506745501">Delay the Inevitable</card>
   </section>
+  <section name="Sideboard" shared="False" />
+  <section name="Special" shared="False" />
   <section name="Skill" shared="False" />
   <section name="Weakness" shared="False" />
-  <section name="Sideboard" shared="False">
-    <card qty="1" id="97278962-9d51-44ab-92d9-b8307da166ea">Physical Training</card>
-    <card qty="1" id="65f0cf81-c907-4d8d-b05a-4f4f610056ee">.45 Automatic</card>
-  </section>
   <section name="Basic Weaknesses" shared="False" />
   <section name="Agenda" shared="True" />
   <section name="Act" shared="True" />

--- a/o8g/Decks/05 - The Circle Undone/Prologue - Penny White.o8d
+++ b/o8g/Decks/05 - The Circle Undone/Prologue - Penny White.o8d
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf" sleeveid="0">
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
   <section name="Investigator" shared="False">
     <card qty="1" id="dfcb02c6-c641-4983-990a-61c07ebb6d4c">Penny White</card>
     <card qty="1" id="f136076f-a794-4979-a739-da6c51758aad">Penny White</card>
   </section>
-  <section name="Special" shared="False" />
   <section name="Asset" shared="False">
     <card qty="1" id="aa11a439-94d5-40b2-b406-e9474339cdea">Stray Cat</card>
-    <card qty="1" id="8d1a826a-6d65-41fe-a487-55dbe23fd108">Knife</card>
-    <card qty="1" id="2bce6c96-d9dc-44fa-8b5d-9899dd6ff151">Flashlight</card>
+    <card qty="2" id="8d1a826a-6d65-41fe-a487-55dbe23fd108">Knife</card>
+    <card qty="2" id="2bce6c96-d9dc-44fa-8b5d-9899dd6ff151">Flashlight</card>
+    <card qty="1" id="eeec305a-af17-46f2-9fa2-78dffccb5999">Dig Deep</card>
   </section>
   <section name="Event" shared="False">
     <card qty="1" id="fdfe0b97-d37e-4f06-9925-1b7b5e5fbb1a">Lucky!</card>
@@ -17,12 +17,9 @@
   <section name="Skill" shared="False">
     <card qty="2" id="d5b60e5a-cb31-4b98-9c40-aed4322a2347">Able Bodied</card>
   </section>
+  <section name="Sideboard" shared="False" />
+  <section name="Special" shared="False" />
   <section name="Weakness" shared="False" />
-  <section name="Sideboard" shared="False">
-    <card qty="1" id="eeec305a-af17-46f2-9fa2-78dffccb5999">Dig Deep</card>
-    <card qty="1" id="8d1a826a-6d65-41fe-a487-55dbe23fd108">Knife</card>
-    <card qty="1" id="2bce6c96-d9dc-44fa-8b5d-9899dd6ff151">Flashlight</card>
-  </section>
   <section name="Basic Weaknesses" shared="False" />
   <section name="Agenda" shared="True" />
   <section name="Act" shared="True" />

--- a/o8g/Decks/05 - The Circle Undone/Prologue - Valentino Rivas.o8d
+++ b/o8g/Decks/05 - The Circle Undone/Prologue - Valentino Rivas.o8d
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf" sleeveid="0">
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
   <section name="Investigator" shared="False">
     <card qty="1" id="6e9e0773-f7e4-43ae-8ffa-620920faf22d">Valentino Rivas</card>
     <card qty="1" id="300e6ad9-dd9e-4565-b2e0-b4a16ed891ec">Valentino Rivas</card>
   </section>
-  <section name="Special" shared="False" />
   <section name="Asset" shared="False">
     <card qty="1" id="593e0f81-fbce-4600-a9ba-10fdf73a7054">.41 Derringer</card>
+    <card qty="1" id="8ed7541a-893c-47db-96df-152e8950abc5">Well Connected</card>
   </section>
   <section name="Event" shared="False">
     <card qty="1" id="a587e7a6-1668-40d1-825d-3b7bd6e63569">Sure Gamble</card>
@@ -16,10 +16,9 @@
   <section name="Skill" shared="False">
     <card qty="1" id="c8e50677-51af-411c-8350-593dcb0cac5d">Opportunist</card>
   </section>
+  <section name="Sideboard" shared="False" />
+  <section name="Special" shared="False" />
   <section name="Weakness" shared="False" />
-  <section name="Sideboard" shared="False">
-    <card qty="1" id="8ed7541a-893c-47db-96df-152e8950abc5">Well Connected</card>
-  </section>
   <section name="Basic Weaknesses" shared="False" />
   <section name="Agenda" shared="True" />
   <section name="Act" shared="True" />

--- a/o8g/Decks/104 - Guardians of the Abyss/1 - The Eternal Slumber.o8d
+++ b/o8g/Decks/104 - Guardians of the Abyss/1 - The Eternal Slumber.o8d
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Act" shared="True">
+    <card qty="1" id="d7f62f90-8f21-46fe-8e6e-80dc5ee2f074">Curse of Endless Sleep</card>
+    <card qty="1" id="37bca18b-3e9a-4269-9909-bb14ac77525b">Secrets in the Sand</card>
+    <card qty="1" id="b8eec1aa-6855-4304-aa84-335c400fcb24">The Hour of Judgment</card>
+  </section>
+  <section name="Agenda" shared="True">
+    <card qty="1" id="c550a922-9c5f-4a6b-bab7-57c6726716fd">Jessie’s Request</card>
+    <card qty="1" id="316af1a0-ffac-48d7-a4b9-f6c157327d49">Curse of the Abyss</card>
+    <card qty="1" id="0c545af9-7363-4430-b350-73f636214099">Garden of Shadows</card>
+  </section>
+  <section name="Location" shared="True">
+    <card qty="1" id="6f4123d8-df0f-40a2-a5c2-e01c8b676444">Sandswept Ruins</card>
+    <card qty="1" id="f8882391-13f3-4e1e-9614-79bd1d12c4de">Desert Oasis</card>
+    <card qty="1" id="f2cd435e-4d43-4128-be45-1a0a04dfa933">Faceless Sphinx</card>
+    <card qty="1" id="7de5bf96-e674-480b-8944-631473054e2d">Untouched Vault</card>
+    <card qty="1" id="520ddac8-f418-447d-949c-65e033ef3f0a">Dunes of the Sahara</card>
+    <card qty="1" id="35c1b734-a07b-48b2-8534-183323cb0a42">Sands of Dashur</card>
+    <card qty="1" id="ac578029-0943-47e4-b3ed-8575726802c7">Nile River</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="3" id="f7aa7f85-2d45-4e5c-bf57-065e688acdb1">Abyssal Reach</card>
+    <card qty="2" id="bb043564-e25b-405d-a70d-3438a4ccfa85">The Black Wind</card>
+    <card qty="2" id="8f1bf2cb-5bf1-41f6-9cea-f4ad0a5faac5">Dark Sacrifice</card>
+    <card qty="2" id="df1ce467-6df1-4f5a-ad8d-45da14b0e356">Slumber</card>
+    <card qty="3" id="47ba1874-fa8f-4ebf-a13a-6ba8443d06da">Swarm of Locusts</card>
+    <card qty="3" id="1d584d46-29fc-4236-bb66-3448657afbd5">Terror Under the Pyramids</card>
+    <card qty="3" id="06868b35-d2fd-4f77-8fac-8ea464edc3eb">Sandstorm</card>
+    <card qty="3" id="ced0d25b-5bb6-4d95-8d5c-ee67dccbcaad">Eclipse</card>
+    <card qty="2" id="c493e428-7118-4511-9061-443fc721553f">Thing in the Sarcophagus</card>
+    <card qty="2" id="55a4cdfe-8f94-40db-8b56-a979a60b0bc3">Creature from the Abyss</card>
+    <card qty="3" id="eb866de6-adfd-477c-9497-4d7c018fb6fc">Humble Supplicant</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="d75b87c4-c7ed-4b63-a22c-26b53ce329b1">The Eternal Slumber</card>
+    <card qty="1" id="2bf4d54f-e282-4ef1-b053-e3ede9fed974">Cairo Bazaar</card>
+    <card qty="1" id="b5def4cb-4ffb-4f1c-a392-bc04f93547ef">Streets of Cairo</card>
+    <card qty="1" id="c9035367-ebae-436e-9c7d-258c7a55baed">Expedition Camp</card>
+    <card qty="1" id="244db7a4-79c5-4b44-a3e1-8c367f6448fc">Temple Courtyard</card>
+    <card qty="1" id="f3f9f4c2-2d2a-43f4-abaf-fe22fa3fa661">Outskirts of Cairo</card>
+    <card qty="1" id="46f53b5c-30ec-49f6-b9a3-a985bf61d11b">Museum of Egyptian Antiquities</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="2" id="6f83b462-b1b7-4a89-bf88-451107cfd372">Abyssal Revenant</card>
+    <card qty="1" id="ba44ac48-e286-4f18-aac0-a06dcb16842d">Neith</card>
+  </section>
+  <section name="Second Special" shared="True">
+    <card qty="1" id="9ebacd6c-7f37-4051-98ea-530141d18e30">Professor Nathaniel Taylor</card>
+    <card qty="1" id="8728bd85-572a-4ec9-b518-6e2676f267eb">Nassor</card>
+    <card qty="1" id="01a1356f-be9c-4cf2-94f8-544baa853d9f">Farid</card>
+    <card qty="1" id="76f6e377-7192-4ed6-81a7-6c8852090f8f">Nadia Nimr</card>
+    <card qty="1" id="24eef006-8861-42ea-aa67-950288e1e1de">Dr. Wentworth Moore</card>
+    <card qty="1" id="586f9776-c2f6-468b-afff-63b625902eae">Dr. Layla El Masri</card>
+  </section>
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Chaos Bag" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Decks/104 - Guardians of the Abyss/2 - The Night’s Usurper.o8d
+++ b/o8g/Decks/104 - Guardians of the Abyss/2 - The Night’s Usurper.o8d
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
+  <section name="Act" shared="True">
+    <card qty="1" id="d54f38db-9a1e-4ef2-8d64-d5b6f4c0dcfc">Search for the Gate</card>
+    <card qty="1" id="94a8e53e-27e1-4fa4-9e57-1271d441d187">Into the Gate</card>
+    <card qty="1" id="65c41f55-1d72-4052-8ea9-c5a2bcb330a5">The Night’s Usurper</card>
+  </section>
+  <section name="Agenda" shared="True">
+    <card qty="1" id="74e12e40-655d-4475-b829-3d2feae1b6a5">The Brotherhood Bides Their Time</card>
+    <card qty="1" id="53072c63-caa4-4d1b-b602-d6748c68a4f3">Schemes in the Dark Beyond</card>
+  </section>
+  <section name="Location" shared="True">
+    <card qty="1" id="47ba1874-fa8f-4ebf-a13a-6ba8443d06da">Swarm of Locusts</card>
+    <card qty="1" id="1d584d46-29fc-4236-bb66-3448657afbd5">Terror Under the Pyramids</card>
+    <card qty="1" id="f7aa7f85-2d45-4e5c-bf57-065e688acdb1">Abyssal Reach</card>
+    <card qty="1" id="bb043564-e25b-405d-a70d-3438a4ccfa85">The Black Wind</card>
+    <card qty="1" id="6f4123d8-df0f-40a2-a5c2-e01c8b676444">Sandswept Ruins</card>
+    <card qty="1" id="f8882391-13f3-4e1e-9614-79bd1d12c4de">Desert Oasis</card>
+    <card qty="1" id="f2cd435e-4d43-4128-be45-1a0a04dfa933">Faceless Sphinx</card>
+    <card qty="1" id="7de5bf96-e674-480b-8944-631473054e2d">Untouched Vault</card>
+    <card qty="1" id="520ddac8-f418-447d-949c-65e033ef3f0a">Dunes of the Sahara</card>
+    <card qty="1" id="35c1b734-a07b-48b2-8534-183323cb0a42">Sands of Dashur</card>
+    <card qty="1" id="ac578029-0943-47e4-b3ed-8575726802c7">Nile River</card>
+  </section>
+  <section name="Encounter" shared="True">
+    <card qty="2" id="f7aa7f85-2d45-4e5c-bf57-065e688acdb1">Abyssal Reach</card>
+    <card qty="1" id="bb043564-e25b-405d-a70d-3438a4ccfa85">The Black Wind</card>
+    <card qty="2" id="8f1bf2cb-5bf1-41f6-9cea-f4ad0a5faac5">Dark Sacrifice</card>
+    <card qty="2" id="df1ce467-6df1-4f5a-ad8d-45da14b0e356">Slumber</card>
+    <card qty="2" id="47ba1874-fa8f-4ebf-a13a-6ba8443d06da">Swarm of Locusts</card>
+    <card qty="2" id="1d584d46-29fc-4236-bb66-3448657afbd5">Terror Under the Pyramids</card>
+    <card qty="3" id="06868b35-d2fd-4f77-8fac-8ea464edc3eb">Sandstorm</card>
+    <card qty="3" id="ced0d25b-5bb6-4d95-8d5c-ee67dccbcaad">Eclipse</card>
+    <card qty="2" id="c493e428-7118-4511-9061-443fc721553f">Thing in the Sarcophagus</card>
+    <card qty="2" id="6f83b462-b1b7-4a89-bf88-451107cfd372">Abyssal Revenant</card>
+    <card qty="2" id="72d4d7b8-2eac-4de9-9dd9-4a37183a1404">Speaker for the Dark Pharaoh</card>
+  </section>
+  <section name="Setup" shared="True">
+    <card qty="1" id="879846b9-e547-4c81-8119-ad8974e02798">The Night’s Usurper</card>
+    <card qty="1" id="c9035367-ebae-436e-9c7d-258c7a55baed">Expedition Camp</card>
+  </section>
+  <section name="Special" shared="True">
+    <card qty="1" id="ee6c2283-3de1-42c3-b5a5-242cebabf330">Xzharah</card>
+    <card qty="2" id="6b903f61-70aa-4436-8985-d164cace2f70">Dreaded Shantak</card>
+    <card qty="1" id="c640bf96-f9c8-4f45-a60a-872d992eb8f1">Eldritch Gate</card>
+    <card qty="1" id="5b9fd7fb-e348-4a84-8ee0-8b5a8b413846">Mist-Filled Caverns</card>
+    <card qty="1" id="c0b5e8c9-477d-43b2-9eb8-467e08cd758a">Stairway to Sarkomand</card>
+    <card qty="1" id="66a80678-c5ed-48e8-9029-df6ecb33247b">Tunnels under Ngranek</card>
+    <card qty="1" id="154eac12-b7ef-406a-a3dc-a51f81cb7b20">The Great Abyss</card>
+    <card qty="1" id="766a822a-c927-4faf-b1c1-1b5cce3a8d10">A Dream Betwixt</card>
+  </section>
+  <section name="Second Special" shared="True">
+    <card qty="1" id="9ebacd6c-7f37-4051-98ea-530141d18e30">Professor Nathaniel Taylor</card>
+    <card qty="1" id="8728bd85-572a-4ec9-b518-6e2676f267eb">Nassor</card>
+    <card qty="1" id="01a1356f-be9c-4cf2-94f8-544baa853d9f">Farid</card>
+    <card qty="1" id="76f6e377-7192-4ed6-81a7-6c8852090f8f">Nadia Nimr</card>
+    <card qty="1" id="24eef006-8861-42ea-aa67-950288e1e1de">Dr. Wentworth Moore</card>
+    <card qty="1" id="586f9776-c2f6-468b-afff-63b625902eae">Dr. Layla El Masri</card>
+  </section>
+  <section name="Investigator" shared="False" />
+  <section name="Special" shared="False" />
+  <section name="Asset" shared="False" />
+  <section name="Event" shared="False" />
+  <section name="Skill" shared="False" />
+  <section name="Weakness" shared="False" />
+  <section name="Sideboard" shared="False" />
+  <section name="Basic Weaknesses" shared="False" />
+  <section name="Chaos Bag" shared="True" />
+  <notes><![CDATA[]]></notes>
+</deck>

--- a/o8g/Sets/Before the Black Throne/set.xml
+++ b/o8g/Sets/Before the Black Throne/set.xml
@@ -1,0 +1,484 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<set gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" id="95daca66-e3e6-4e72-a1c5-1765aea578a0" name="Before the Black Throne" standalone="True" version="1.0.0" xmlns:noNamespaceSchemaLocation="CardSet.xsd">
+  <cards>
+    <card id="ad1777aa-8325-4d75-b774-9bb0e0c74f9e" name="Hallowed Mirror">
+      <property name="Card Number" value="313" />
+      <property name="Quantity" value="1" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Relic. Occult. Blessed." />
+      <property name="Text" value="Limit 1 per deck.Forced – After Hallowed Mirror enters play: Search your bonded cards for 3 copies of Soothing Melody. Add 1 to your hand and shuffle the other 2 into your deck. When Hallowed Mirror leaves play, find each of those copies of Soothing Melody (even if they are out of play) and remove them from the game." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Accessory" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="13901510-7669-4e5c-ac27-71646b359818" name="Soothing Melody">
+      <property name="Card Number" value="314" />
+      <property name="Quantity" value="3" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="Bonded (Hallowed Mirror).Heal 2 damage or 2 horror (or any combination thereof) from among investigators and/or Ally assets at your location. Draw 1 card." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="άέί" />
+    </card>
+    <card id="4062e3ed-530d-4bfd-8f39-f5e6ad5eca5c" name="“I’ve had worse…”">
+      <property name="Card Number" value="315" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Spirit." />
+      <property name="Text" value="Fast. Play when you are dealt damage and/or horror.Cancel up to 2 damage and/or horror just dealt to you. Then, gain that many resources." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="2" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="άί" />
+    </card>
+    <card id="747ff2e8-4f17-43f8-952c-376b8aacd09d" name="Occult Lexicon">
+      <property name="Card Number" value="316" />
+      <property name="Quantity" value="1" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tome. Occult." />
+      <property name="Text" value="Limit 1 per deck.Forced – After Occult Lexicon enters play: Search your bonded cards for 3 copies of Blood-Rite. Add 1 to your hand and shuffle the other 2 into your deck. When Occult Lexicon leaves play, find each of those copies of Blood-Rite (even if they are out of play) and remove them from the game." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="έ" />
+    </card>
+    <card id="d0f4baa1-b066-47a0-a43f-9160efe57818" name="Blood-Rite">
+      <property name="Card Number" value="317" />
+      <property name="Quantity" value="3" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="Bonded (Occult Lexicon).Draw 2 cards. Discard up to 2 cards from your hand. For each card thusly discarded, you may either gain 1 resource, or spend 1 resource to deal 1 damage to an enemy at your location. This action does not provoke attacks of opportunity." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="άέή" />
+    </card>
+    <card id="78cb916a-e28d-4505-98aa-6e42d0e4ce69" name="Glimpse the Unthinkable">
+      <property name="Card Number" value="318" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Insight." />
+      <property name="Text" value="Shuffle any number of non-weakness cards from your hand into your deck. Draw cards until you reach your maximum hand size. Remove Glimpse the Unthinkable from the game." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="5" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="3" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="έέέ" />
+    </card>
+    <card id="246df79c-c5b5-4be9-9167-b1603973f50e" name="“You owe me one!”">
+      <property name="Card Number" value="319" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Favor. Gambit." />
+      <property name="Text" value="Look at another investigator’s hand. You may play a non-weakness card in that investigator’s hand, under your control. If you do, you and that investigator each draw 1 card." />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="έήί" />
+    </card>
+    <card id="29b7c267-3ec5-4693-b25d-79cbb7d064f6" name="Double, Double">
+      <property name="Card Number" value="320" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ritual." />
+      <property name="Text" value="Exceptional.ι After you play an event, exhaust Double, Double: Play that event again as if it were in your hand." />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="4" />
+      <property name="Cost" value="4" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Arcane" />
+      <property name="Skill Icons" value="άέ" />
+    </card>
+    <card id="6287a4d3-694e-4d93-83f1-85a8a4c73c16" name="Wither">
+      <property name="Card Number" value="321" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="η: Fight. This attack uses [ά] instead of [ή]. You get +2 [ά] for this attack. If a α, β, γ, or δ symbol is revealed during this attack, the attacked enemy gets –1 fight, –1 health, and –1 evade for the remainder of the turn (to a minimum of 1)." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="4" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Arcane" />
+      <property name="Skill Icons" value="ήή" />
+    </card>
+    <card id="5c700a72-b4ec-4c7a-bfa9-dc6dc4fc6144" name="Sixth Sense">
+      <property name="Card Number" value="322" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="η: Investigate. Investigate using [ά] instead of [έ]. You get +2 [ά] for this investigation. If a α, β, γ, or δ symbol is revealed during this test, you may choose a revealed location up to 2 connections away from your location; you are now investigating as if you were at the chosen location instead of your location (you may use either shroud value)." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="4" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="2" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Arcane" />
+      <property name="Skill Icons" value="έέ" />
+    </card>
+    <card id="21b8d017-25a0-4d2e-b4ea-52490b8f19c9" name="Lure">
+      <property name="Card Number" value="323" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Trick." />
+      <property name="Text" value="Attach to your location or to a connecting location.During the enemy phase, each enemy that moves does so along the shortest path toward the attached location, instead of to where it would normally move.Forced – While attached, at the end of the round: Discard Lure." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="2" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="2" />
+      <property name="Skill Icons" value="ίί" />
+    </card>
+    <card id="8dc70ce2-7908-4e67-aaef-0932abb00d18" name="Eucatastrophe">
+      <property name="Card Number" value="324" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Fortune. Blessed." />
+      <property name="Text" value="Fast. Play when you reveal a chaos token that would reduce your skill value to 0 during a skill test (including the ζ token).Cancel that token and treat it as an ε token, instead." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ΰΰ" />
+    </card>
+    <card id="6febb6ad-ef14-4445-8bc7-717919cc26b8" name="Before the Black Throne" size="EncounterCard">
+      <property name="Card Number" value="325" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Subtitle" value="EASY / STANDARD" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –X. X is half of the doom on Azathoth (rounded up), to a minimum of 2.β: Reveal another token. If you fail, search the encounter deck and discard pile for a Cultist enemy and draw it. Shuffle the encounter deck.γ: –2. If you fail, Azathoth attacks you.δ: –4. If your modified skill value for this test is 0, place 1 doom on Azathoth." />
+      <alternate name="Before the Black Throne" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Subtitle" value="HARD / EXPERT" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –X. X is the amount of doom on Azathoth, to a minimum of 2.β: Reveal another token. If you fail, search the encounter deck and discard pile for a Cultist enemy and draw it. Shuffle the encounter deck.γ: –3. If you fail, Azathoth attacks you.δ: –6. If your modified skill value for this test is 0, place 1 doom on Azathoth." />
+      </alternate>
+    </card>
+    <card id="1243ebf8-6f47-466c-9202-7534c9fc1a34" name="WHEEL OF FORTUNE · X" size="HorizCard">
+      <property name="Card Number" value="326" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Subtitle" value="Agenda 1a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each location is connected to each location adjacent to it.Do not remove doom from enemies when this agenda advances." />
+      <property name="Doom" value="4" />
+      <alternate name="Rejoice, For the End is Near!" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Subtitle" value="Agenda 1b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="Somehow, you’re not the only human here. They are but mindless husks—almost entirely devoid of humanity, nothing but flesh, muscle, and bone, preserved for eternity in their single-minded passion, kneeling and chanting in foul worship: “Azathoth! Azathoth! The end has come!”Each Cultist enemy commits ritual suicide. Discard each Cultist enemy in play and move all doom from them to Azathoth.The lead investigator must search the encounter deck and discard pile for a copy of Daemonic Piping and draw it.Endless walkways and steps of black stone are the only routes which guide you to your destination. It is an impossible maze to navigate.Check Campaign Log. If Gilman’s Journal is listed under “Mementos Discovered,” you are able to find you way. Otherwise, you become hopelessly lost; each investigator must either move to the location to his or her left, or move the placement of his or her location once to the left (placing an empty space in the spot it previously occupied). A location cannot move more than once via this effect." />
+      </alternate>
+    </card>
+    <card id="cb7c6a83-05c2-4210-a1e7-9130b806ab72" name="It Awaits" size="HorizCard">
+      <property name="Card Number" value="327" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Subtitle" value="Agenda 2a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each location is connected to each location adjacent to it.Do not remove doom from enemies when this agenda advances." />
+      <property name="Doom" value="6" />
+      <alternate name="Gnawing Hungrily" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Subtitle" value="Agenda 2b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="Each Cultist enemy commits ritual suicide. Discard each Cultist enemy in play and move all doom from them to Azathoth.The lead investigator must search the encounter deck and discard pile for a copy of Daemonic Piping and draw it.In this oblivion outside time, nothing is as it should be. The mist dances and churns around you. Laughter mocks you from beyond, and out from the dark nebulae emerges a familiar wraith, a being which should be long dead.Check Campaign Log. If Worn Crucifix is listed under “Mementos Discovered,” the wraith recognizes the crucifix you stole from Walter Gilman’s room and backs away slowly, slinking into the darkness beyond.Otherwise, the wraith attacks you; each investigator must test [ά] (4). Each investigator who fails takes 1 damage and 1 horror." />
+      </alternate>
+    </card>
+    <card id="a1a82dd1-3db2-4ebd-b73c-b54f43e7e4a4" name="The Final Countdown" size="HorizCard">
+      <property name="Card Number" value="328" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Subtitle" value="Agenda 3a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each location is connected to each location adjacent to it.Do not remove doom from enemies when this agenda advances.(Beware—The scenario will not end when this agenda advances, but the doom of the world grows nigh.)" />
+      <property name="Doom" value="8" />
+      <alternate name="Azathoth Stirs..." size="HorizCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Subtitle" value="Agenda 3b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="Each Cultist enemy commits ritual suicide. Discard each Cultist enemy in play and move all doom from them to Azathoth.The lead investigator must search the encounter deck and discard pile for a copy of Daemonic Piping and draw it.There is no longer an agenda deck, but the scenario is not over. Until the end of the scenario, doom that would be placed on the current agenda is instead placed on Azathoth, and all doom in play is considered to be on Azathoth.You come across another circle of Azathoth’s worshippers, led by a hooded, shapeless form which holds an ancient lantern high above its head. The lantern’s dim grey light scarcely pierces the realm’s darkness. Somehow, the phantom is familiar to you; some vague sense of kinship drives you onward.Check Campaign Log. If Corn Husk Doll is listed under “Mementos Discovered,” the creature recognizes you, as well. It peers at you curiously, and the circle of prayer is silenced; remove 1 doom from Azathoth.Otherwise, the creature barely notices you, and the circle resumes its chanting." />
+      </alternate>
+    </card>
+    <card id="c2141986-a61d-46b3-a857-aa7183990531" name="The Cosmos Beckons" size="HorizCard">
+      <property name="Card Number" value="329" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Subtitle" value="Act 1a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="η Spend X clues: Draw the top X cards of the Cosmos. Choose one to put into play using its “Cosmos –” instructions, and move to it. Shuffle the rest back into the Cosmos.Objective – Only investigators at Hideous Palace may spend the requisite number of clues, as a group, to advance. (Beware—any investigator who is not there will be killed.)" />
+      <property name="Clues" value="1π" />
+      <alternate name="Palace of the Old Ones" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Subtitle" value="Act 1b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Your steed carries you through the entryway of the nightmarish palace, and you are surprised to find the halls inside to be as vast and cavernous as the empty space surrounding it. It is as though the doorway was but the threshold of another universe, as desolate and boundless as the last.Remove Cosmic Ingress from the game. Shuffle each location in play other than Hideous Palace into the Cosmos. Each investigator at those locations is left behind and is killed. Each enemy at those locations is shuffled into the top 5 cards of the encounter deck.Take the set-aside Court of the Great Old Ones and the top 2 cards of the Cosmos, and shuffle them so you cannot tell which is which. Then, put them into play along with empty space, as depicted in “Location Placement for Act 2” in the Campaign Guide.Each investigator draws the top card of the encounter deck." />
+      </alternate>
+    </card>
+    <card id="1fc155f2-323e-4418-9e4c-a970adc5d44f" name="In Azathoth’s Domain" size="HorizCard">
+      <property name="Card Number" value="330" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Subtitle" value="Act 2a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="η Spend X clues: Draw the top X cards of the Cosmos. Choose one to put into play using its “Cosmos –” instructions, and move to it. Shuffle the rest back into the Cosmos.Objective – Only investigators at Court of the Great Old Ones may spend the requisite number of clues, as a group, to advance. (Beware—any investigator who is not there will be killed.)" />
+      <property name="Clues" value="2π" />
+      <alternate name="Nucleus of the Universe" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Subtitle" value="Act 2b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="The winged creature lands on a winding walkway of black stone, extending into a ceaseless horizon of pitched void. It takes some prodding and encouragement before your steed continues onward. Even the most dreadful of beasts are terrified of this place, it seems. Yet still, you can hear the mindless chanting of those who dwell closest to the daemon-sultan, the maddening whining of the pipers, the monotonous drum-beats which thrum endlessly in your mind...Remove Hideous Palace from the game. Shuffle each location in play other than Court of the Great Old Ones into the Cosmos. Each investigator at those locations is left behind and is killed. Each enemy at those locations is shuffled into the top 5 cards of the encounter deck.Take the set-aside The Black Throne and the top 3 cards of the Cosmos, and shuffle them so you cannot tell which is which. Then, put them into play along with empty space, as depicted in “Location Placement for Act 3” in the Campaign Guide.Each investigator draws the top card of the encounter deck." />
+      </alternate>
+    </card>
+    <card id="98ed9247-476e-4821-91b0-962429d6cacd" name="What Must Be Done" size="HorizCard">
+      <property name="Card Number" value="331" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Subtitle" value="Act 3a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="η Spend X clues: Draw the top X cards of the Cosmos. Choose one to put into play using its “Cosmos –” instructions, and move to it. Shuffle the rest back into the Cosmos.Objective – If the lead investigator is at The Black Throne and there are no clues on it, advance." />
+      <alternate name="The End" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Subtitle" value="Act 3b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="You stand on a precipice before the Black Throne and gaze up at the blind, voiceless monstrosity that is Azathoth. The mere sight of it causes your vision to blur and your body to shake uncontrollably. The monotonous piping is so loud now, it rattles your bones and nearly causes you to vomit from the force upon your insides. Blood drips from your eyes and your ears.Should Azathoth awaken, it will devour every world that ever was. You must act now, before it is too late.Check Campaign Log. —If at least two of the following are true, you may proceed to (→R2): You accepted your fate, Mesmerizing Flute is listed under “Mementos Discovered,” and Ritual Components is listed under “Mementos Discovered.”—If at least two of the following are true, you may proceed to (→R3): You rejected your fate, Scrap of Torn Shadow is listed under “Mementos Discovered,” and Wisp of Spectral Mist is listed under “Mementos Discovered.”—Otherwise, (→R4)." />
+      </alternate>
+    </card>
+    <card id="fd8a0dd1-5c6f-423c-9bf9-8c65f9fa9532" name="Cosmic Ingress" size="EncounterCard">
+      <property name="Card Number" value="332" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Cosmic Ingress" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Forced – At the end of the round: Add clues to Cosmic Ingress until it has 3 clues on it.Each Void location gains: “η: Shuffle this location into the Cosmos, moving each investigator and enemy that was at this location to Cosmic Ingress.”" />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="3" />
+      </alternate>
+    </card>
+    <card id="8474e4b7-2f14-4a5f-811e-32a24106eb6c" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="333" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Hideous Palace" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Forced – At the end of the round: Add clues to Hideous Palace until it has 4 clues on it.Each Void location gains: “η: Shuffle this location into the Cosmos, moving each investigator and enemy that was at this location to Hideous Palace.”" />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="4" />
+      </alternate>
+    </card>
+    <card id="bd10b235-6a1c-4744-91ff-e2684507e0ee" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="334" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Court of the Great Olds Ones" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Forced – At the end of the round: Add clues to Court of the Great Old Ones until it has 6 clues on it.Each Void location gains: “η: Shuffle this location into the Cosmos, moving each investigator and enemy that was at this location to Court of the Great Old Ones.”" />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="6" />
+      </alternate>
+    </card>
+    <card id="a02f9ddf-b3f2-45d8-9717-4097857ac31c" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="335" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="The Black Throne" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="The Black Throne gets +X shroud, where X is half of the doom on Azathoth (rounded up).Haunted – You must either place 1 doom on Azathoth, or Azathoth attacks you." />
+        <property name="Shroud" value="1" />
+        <property name="Clues" value="2π" />
+      </alternate>
+    </card>
+    <card id="b728dcad-e66e-4868-a8b3-059f2c7ec47f" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="336" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Dancer's Mist" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Cosmos – You must either connect to the right, or lose 2 resources and connect to an adjacent location in a direction of your choice.ι After you move to Dancer’s Mist, remove 1 resource from the scenario reference card: Move to a connecting location." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="2" />
+      </alternate>
+    </card>
+    <card id="b3f94eaf-7b7b-4c71-971e-e0f85bf4a276" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="337" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Flight into Oblivion" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Cosmos – You must either connect above, or take 2 horror and connect to the topmost revealed location in a direction of your choice.η Remove 1 resource from the scenario reference card: Move the placement of Flight into Oblivion once upward, placing an empty space in the spot it previously occupied. (Group limit once per game.)" />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="1" />
+      </alternate>
+    </card>
+    <card id="0bea9f77-2890-455b-857f-a36659f40ef8" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="338" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Infinity of Darkness" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Cosmos – You must either connect below, or take 2 damage and connect to the bottommost revealed location in a direction of your choice.η Remove 1 resource from the scenario reference card: Move the placement of Infinity of Darkness once downward, placing an empty space in the spot it previously occupied. (Group limit once per game.)" />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="1" />
+      </alternate>
+    </card>
+    <card id="12b495bf-d262-4462-85b3-baf8388c23fb" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="339" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Cosmic Gate" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Cosmos – Connect to any revealed location, in a direction of your choice.Forced – After you enter Cosmic Gate: You must either spend 1 clue or take 1 horror.η Remove 1 resource from the scenario reference card: Move any number of investigators at Cosmic Gate to any other Void location." />
+        <property name="Shroud" value="1" />
+        <property name="Clues" value="1" />
+      </alternate>
+    </card>
+    <card id="f0883c1c-1ad2-46b9-bd87-1d3d5cd8f342" name="Cosmos" size="EncounterCard">
+      <property name="Card Number" value="340" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld." />
+      <alternate name="Pathway into Void" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Before the Black Throne" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Otherworld." />
+        <property name="Text" value="Cosmos – Connect in a direction of your choice.Forced – After you enter Pathway into Void: You must either discard 1 card from your hand or take 1 damage.η Remove 1 resource from the scenario reference card: Move Pathway into Void to any adjacent spot, placing an empty space in the spot it previously occupied. (Group limit once per turn.)" />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="2" />
+      </alternate>
+    </card>
+    <card id="f82c2ee2-3061-4484-ae50-6afb13144588" name="Mindless Dancer" size="EncounterCard">
+      <property name="Card Number" value="341" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster." />
+      <property name="Text" value="Spawn – Farthest empty space.Hunter.Mindless Dancer can enter empty space as if it were a location.Forced – After Mindless Dancer moves to an empty space via its hunter keyword: Resolve its hunter keyword again. (Limit once per round.)" />
+      <property name="Health" value="5" />
+      <property name="Combat" value="6" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="2" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="280f5c41-3ae0-462d-9a67-e46c8cf02d62" name="Ultimate Chaos" size="EncounterCard">
+      <property name="Card Number" value="342" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Power." />
+      <property name="Text" value="Revelation – Test [ά] (4). If you fail, attach Ultimate Chaos to Azathoth. If you fail by 2 or more, take 1 damage and 1 horror. If you fail by 3 or more, Ultimate Chaos gains surge. Cannot be canceled.If there are 3 copies of Ultimate Chaos attached to Azathoth, discard them and either place 1 doom on Azathoth, or Azathoth attacks each investigator in player order. Cannot be canceled." />
+    </card>
+    <card id="d56e90f0-5778-4f3d-8648-7736f402dbe3" name="Whispered Bargain" size="EncounterCard">
+      <property name="Card Number" value="343" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Pact." />
+      <property name="Text" value="Peril.Revelation – You must either (choose one): Place 1 doom on Azathoth, or Azathoth attacks you." />
+    </card>
+    <card id="d4ae91ab-d75b-4931-8315-3ab491184cc4" name="The End is Nigh!" size="EncounterCard">
+      <property name="Card Number" value="344" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Endtimes." />
+      <property name="Text" value="Revelation – Test [ά] (1). This test gets +X difficulty, where X is the current agenda number. If there is no agenda in play, X is 4. If you fail, place 1 doom on Azathoth." />
+    </card>
+    <card id="f5245cce-527b-4ea8-9394-f8a45cea9ea1" name="A World in Darkness" size="EncounterCard">
+      <property name="Card Number" value="345" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Endtimes." />
+      <property name="Text" value="Revelation – If there is no doom on Azathoth, A World in Darkness gains surge. Otherwise, for each doom on Azathoth, you must choose one:—Lose 1 resource.—Choose and discard 1 card from your hand.—Take 1 horror.—Take 1 damage." />
+    </card>
+    <card id="ab2ec5e1-6170-410a-a5b2-767dbfa02f17" name="Azathoth" size="EncounterCard">
+      <property name="Card Number" value="346" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Before the Black Throne" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Ancient One. Elite." />
+      <property name="Text" value="Azathoth is oblivious and omnipotent. It is immune to all player card effects and investigator actions, and cannot be defeated by any means.Forced – If there is 10 or more doom on Azathoth: The Blind Idiot God rises from its throne in the ultimate void of Chaos and devours the universe. (-&gt;R1)" />
+      <property name="Health" value="–" />
+      <property name="Damage" value="3" />
+      <property name="Horror" value="3" />
+    </card>
+  </cards>
+</set>

--- a/o8g/Sets/Before the Black Throne/set.xml
+++ b/o8g/Sets/Before the Black Throne/set.xml
@@ -354,7 +354,7 @@
       <property name="Quantity" value="3" />
       <property name="Encounter Set" value="Before the Black Throne" />
       <property name="Type" value="Location" />
-      <property name="Traits" value="Otherworld." />
+      <property name="Traits" value="Otherworld. Void." />
       <alternate name="Dancer's Mist" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Before the Black Throne" />
         <property name="Type" value="Location" />
@@ -373,7 +373,7 @@
       <alternate name="Flight into Oblivion" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Before the Black Throne" />
         <property name="Type" value="Location" />
-        <property name="Traits" value="Otherworld." />
+        <property name="Traits" value="Otherworld. Void." />
         <property name="Text" value="Cosmos – You must either connect above, or take 2 horror and connect to the topmost revealed location in a direction of your choice.η Remove 1 resource from the scenario reference card: Move the placement of Flight into Oblivion once upward, placing an empty space in the spot it previously occupied. (Group limit once per game.)" />
         <property name="Shroud" value="2" />
         <property name="Clues" value="1" />
@@ -388,7 +388,7 @@
       <alternate name="Infinity of Darkness" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Before the Black Throne" />
         <property name="Type" value="Location" />
-        <property name="Traits" value="Otherworld." />
+        <property name="Traits" value="Otherworld. Void." />
         <property name="Text" value="Cosmos – You must either connect below, or take 2 damage and connect to the bottommost revealed location in a direction of your choice.η Remove 1 resource from the scenario reference card: Move the placement of Infinity of Darkness once downward, placing an empty space in the spot it previously occupied. (Group limit once per game.)" />
         <property name="Shroud" value="2" />
         <property name="Clues" value="1" />
@@ -403,7 +403,7 @@
       <alternate name="Cosmic Gate" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Before the Black Throne" />
         <property name="Type" value="Location" />
-        <property name="Traits" value="Otherworld." />
+        <property name="Traits" value="Otherworld. Void." />
         <property name="Text" value="Cosmos – Connect to any revealed location, in a direction of your choice.Forced – After you enter Cosmic Gate: You must either spend 1 clue or take 1 horror.η Remove 1 resource from the scenario reference card: Move any number of investigators at Cosmic Gate to any other Void location." />
         <property name="Shroud" value="1" />
         <property name="Clues" value="1" />
@@ -418,7 +418,7 @@
       <alternate name="Pathway into Void" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Before the Black Throne" />
         <property name="Type" value="Location" />
-        <property name="Traits" value="Otherworld." />
+        <property name="Traits" value="Otherworld. Void." />
         <property name="Text" value="Cosmos – Connect in a direction of your choice.Forced – After you enter Pathway into Void: You must either discard 1 card from your hand or take 1 damage.η Remove 1 resource from the scenario reference card: Move Pathway into Void to any adjacent spot, placing an empty space in the spot it previously occupied. (Group limit once per turn.)" />
         <property name="Shroud" value="4" />
         <property name="Clues" value="2" />

--- a/o8g/Sets/For the Greater Good/set.xml
+++ b/o8g/Sets/For the Greater Good/set.xml
@@ -1,0 +1,650 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<set gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" id="2d5e4280-e9d7-4f52-bee0-0f525bdc5a90" name="For the Greater Good" standalone="True" version="1.0.0" xmlns:noNamespaceSchemaLocation="CardSet.xsd">
+  <cards>
+    <card id="2bdef0d1-34e4-4405-9fd1-d5c2daadada5" name=".45 Thompson">
+      <property name="Card Number" value="186" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Weapon. Firearm. Illicit." />
+      <property name="Text" value="Uses (5 ammo).Ammo spent from .45 Thompson is placed in your resource pool, as resources.η Spend 1 ammo: Fight. You get +2 [ή] and deal +1 damage for this attack." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="6" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="2 Hand" />
+      <property name="Skill Icons" value="ήή" />
+    </card>
+    <card id="b83a5a1e-0562-4856-be25-6dda9fe4fb46" name=".45 Thompson">
+      <property name="Card Number" value="187" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Weapon. Firearm. Illicit." />
+      <property name="Text" value="Uses (5 ammo).η Spend 1 ammo: Fight. You get +2 [ή] and deal +1 damage for this attack. If you succeed by at least X, you may spend 1 ammo to deal this attack’s damage to another enemy at your location, where X is that enemy’s fight value." />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="5" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="2 Hand" />
+      <property name="Skill Icons" value="ήί" />
+    </card>
+    <card id="f6e6bd79-7d2a-4ee8-a469-6e72ebbfa25c" name="Scroll of Secrets">
+      <property name="Card Number" value="188" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tome." />
+      <property name="Text" value="Uses (3 secrets).η Exhaust Scroll of Secrets and spend 1 secret: Look at the bottom 3 cards of any investigator's deck or the encounter deck. You may discard 1 of those cards. You may add 1 of those cards to its owner’s hand. Place the rest of those cards on either the top or bottom of their deck, in any order." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="2" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="έέ" />
+    </card>
+    <card id="8c671c80-d9a1-400d-a11d-75678e3b5bd7" name="Scroll of Secrets">
+      <property name="Card Number" value="189" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tome." />
+      <property name="Text" value="Uses (4 secrets).η Exhaust Scroll of Secrets and spend 1 secret: Look at the top or bottom card of any investigator's deck or the encounter deck. Then, either discard that card, add it to its owner’s hand, place it on the bottom of its deck, or place it on top of its deck." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="άέ" />
+    </card>
+    <card id="2226a4fd-80fe-484c-a0e6-c8c840197f16" name="Tennessee Sour Mash">
+      <property name="Card Number" value="190" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Illicit." />
+      <property name="Text" value="Fast. Uses (2 supplies).θ Exhaust Tennessee Sour Mash and spend 1 supply: You get +3 [ά] for a skill test on a treachery card.η Discard Tennessee Sour Mash: Fight. You get +3 [ή] and deal +1 damage for this attack." />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="άή" />
+    </card>
+    <card id="4c2790b9-46b3-4a74-aa83-d36907c44fa0" name="Tennessee Sour Mash">
+      <property name="Card Number" value="191" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Illicit." />
+      <property name="Text" value="Uses (3 supplies).θ Exhaust Tennessee Sour Mash and spend 1 supply: You get +2 [ά] for a skill test on a treachery card.η Discard Tennessee Sour Mash: Fight. You get +3 [ή] for this attack. If this attack succeeds against a non-Elite enemy, automatically evade it." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="άί" />
+    </card>
+    <card id="d9fc5e84-83e4-473e-b58a-64f10dd5cbe1" name="Enchanted Blade">
+      <property name="Card Number" value="192" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Relic. Weapon. Melee." />
+      <property name="Text" value="Uses (3 charges).η: Fight. You get +2 [ή] for this attack. If you succeed, you may spend 1 charge to empower the blade, dealing +1 damage for this attack. If the blade is empowered and this attack defeats an enemy, draw 1 card and heal 1 horror." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Hand Arcane" />
+      <property name="Skill Icons" value="έή" />
+    </card>
+    <card id="06b78fc0-7600-424a-bded-c1aceb5add95" name="Enchanted Blade">
+      <property name="Card Number" value="193" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Relic. Weapon. Melee." />
+      <property name="Text" value="Uses (4 charges).η: Fight. You get +2 [ή] for this attack. As an additional cost to use this ability, you may spend up to 2 charges to empower the blade (for each charge spent in this way, you get +1 [ή] and deal +1 damage for this attack)." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Hand Arcane" />
+      <property name="Skill Icons" value="άή" />
+    </card>
+    <card id="7ff054ba-8bea-4aca-a5e5-f60540a467ab" name="Grisly Totem">
+      <property name="Card Number" value="194" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Charm. Cursed." />
+      <property name="Text" value="ι After you commit a card to a skill test, exhaust Grisly Totem: That card gains another instance of one of its skill icons of your choice. If that skill test is successful, the performing investigator draws 1 card." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="Accessory" />
+      <property name="Skill Icons" value="άί" />
+    </card>
+    <card id="7ff43b1c-b97f-45e4-9b48-d695deb4479f" name="Grisly Totem">
+      <property name="Card Number" value="195" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Charm. Blessed." />
+      <property name="Text" value="ι After you commit a card to a skill test, exhaust Grisly Totem: That card gains another instance of one of its skill icons of your choice. If that skill test fails, return that card to your hand." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="Accessory" />
+      <property name="Skill Icons" value="άί" />
+    </card>
+    <card id="22e3ab3a-027d-4f4a-9a84-94e076bbc62f" name="The Council’s Coffer">
+      <property name="Card Number" value="196" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Relic." />
+      <property name="Text" value="Uses (1π locks). If there are no locks on The Council’s Coffer, each investigator searches his or her deck or discard pile for any card and immediately plays it at no cost. Exile The Council’s Coffer. (Max once per campaign.)η η: Test any skill (5). If you succeed, remove 1 lock. Any investigator at your location may activate this ability.Card design by The Council at Arkham Nights 2017." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="2" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Unique" value="*" />
+      <property name="Skill Icons" value="" />
+    </card>
+    <card id="37bb6382-1e06-43f8-98c1-9f4c46eae6ae" name="For the Greater Good" size="EncounterCard">
+      <property name="Card Number" value="197" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –X. X is the highest number of doom on a Cultist enemy in play.β: –2. Reveal another token.γ: –3. If you fail, place 1 doom on the nearest Cultist enemy.δ: –3. If you fail, move 1 doom from the nearest Cultist enemy to the current agenda." />
+      <property name="Level" value="1" />
+      <alternate name="For the Greater Good" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –X. X is the total number of doom among Cultist enemies in play.β: –2. Reveal another token.γ: –3. If you fail, place 1 doom on each Cultist enemy in play. If there are no Cultist enemies in play, reveal another token.δ: –3. If you fail, move all doom from the Cultist enemy with the most doom on it to the current agenda. If no Cultist enemies in play have doom on them, reveal another token." />
+        <property name="Level" value="1" />
+      </alternate>
+    </card>
+    <card id="c558324e-609c-4490-9b1a-e8bd88ddba00" name="THE HIEROPHANT · V" size="HorizCard">
+      <property name="Card Number" value="198" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Forced – When you defeat a Silver Twilight enemy: You leave behind some evidence of the scuffle. Move 1 doom from each enemy at that location to the current agenda." />
+      <property name="Level" value="2" />
+      <property name="Doom" value="8" />
+      <alternate name="THE HIEROPHANT · V" size="HorizCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="As you explore the building, you almost wander into a heated debate between several members of the Lodge in a nearby hallway. Seeing an opportunity to learn more, you hide and eavesdrop on the conversation. “Mr. Sanford’s orders are to complete the geist-trap at any cost,” one of them says firmly. “If that means we must put lives in danger, so be it. The good of the many outweigh the good of the few; you know this.”Another member, a woman, pounds her fist on the wall. “No! Our first resort cannot be to spill blood. There must be another way.”“There is no time,” the other responds, and there is a murmur of agreement among the rest. “It is clear you do not have the will to proceed. Take her away. We will make her see for herself the sacrifices that must be made for the greater good.”“No! You can’t do this!” the woman yells. You wince as her screams echo down the corridor. What are they planning to do?Discard the top 5 cards of the encounter deck. In player order, each investigator must draw a Cultist enemy discarded in this way." />
+        <property name="Level" value="2" />
+      </alternate>
+    </card>
+    <card id="28df5d40-3637-4ddc-a344-5a7ffd499bbe" name="Ends and Means" size="HorizCard">
+      <property name="Card Number" value="199" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each Silver Twilight enemy in a Sanctum location loses aloof.Forced – When you defeat a Silver Twilight enemy: You leave behind some evidence of the scuffle. Move 1 doom from each enemy at that location to the current agenda." />
+      <property name="Level" value="1" />
+      <property name="Doom" value="10" />
+      <alternate name="Ends and Means" size="HorizCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="Revelation – Replace the act and agenda decks with The Greater Good. Spawn the set-aside Summoned Beast at the Puzzle Box’s location (or any Sanctum location if the Puzzle Box is not in play) and remove the Puzzle Box from the game." />
+        <property name="Level" value="1" />
+      </alternate>
+    </card>
+    <card id="4d17a25d-481f-4223-b994-611ad03f18c4" name="Warm Welcome" size="HorizCard">
+      <property name="Card Number" value="200" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Act" />
+      <property name="Level" value="1" />
+      <property name="Doom" value="3π" />
+      <alternate name="Warm Welcome" size="HorizCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="“Ah, it’s you.” You are approached by a member of the Lodge whom you recognize: one of Carl Sanford’s bodyguards from your previous meeting with the president. “I regret to inform you that Mr. Sanford and the other members of the Lodge are busy with an important task at the moment. I would suggest you come back at a later time.” You tell the man that your task is important, and offer to help in return for a meeting with Mr. Sanford. He considers you for a moment, then nods. “All right. We are attempting to open a device which we believe will help us bind the revenant you encountered earlier. You’ll want to speak with Nathan Wick if you want to help. You can find him in the library upstairs.” You thank him and turn to leave, but he grabs your arm and stops you, adding one final warning: “You should know that we intend to open this device at any cost. If you cannot stomach the consequences, once again, I suggest you leave.”If the Library is not in play, put it into play.Spawn the set-aside Nathan Wick enemy in the Library, (Master of Initiation) side faceup. Attach the set-aside Puzzle Box story asset to him." />
+        <property name="Level" value="1" />
+      </alternate>
+    </card>
+    <card id="39f80193-d3b1-4137-a14e-cae707519bb3" name="Infiltrating the Lodge" size="HorizCard">
+      <property name="Card Number" value="201" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="ι After you evade an enemy: Remove all doom from it." />
+      <property name="Level" value="2" />
+      <property name="Doom" value="2π" />
+      <alternate name="Infiltrating the Lodge" size="HorizCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="At first, your investigation yields few answers. There is indeed a meeting of some sort happening at the manor tonight, though you’re not sure why. Finally, you catch a break. On a nearby table, a written summons explains the reason for tonight’s gathering:“Our timetable has moved forward. We must complete the trap by midnight tonight. The device we found will aid us in binding the revenant, so it is imperative that we find a way to open it before the ceremony begins. We have no time to waste with prudence or cowardice. Report to Nathan Wick in the sanctum at once.”You are left with more questions than answers.If the Inner Sanctum is not in play, put it into play.Spawn the set-aside Nathan Wick enemy in the Inner Sanctum, (Master of Indoctrination) side faceup. Attach the set-aside Puzzle Box story asset to him.For the remainder of the game, the current act gains “ι After you evade an enemy: Remove all doom from it.” Place this card next to the act deck as a reminder, then advance to act 2a." />
+        <property name="Level" value="2" />
+      </alternate>
+    </card>
+    <card id="0bdfd6d5-3f5f-458a-99ae-208ae010afcb" name="Obtaining the Device" size="HorizCard">
+      <property name="Card Number" value="202" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Objective – If Nathan Wick is added to the victory display by any means, choose an investigator to take control of the attached Puzzle Box, and advance." />
+      <property name="Level" value="3" />
+      <alternate name="Obtaining the Device" size="HorizCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="If you advanced by defeating Nathan Wick:You quickly pry the device from Nathan’s hands and flee before you are noticed.If you advanced by evading Nathan Wick:You wait until Nathan is not looking, then sweep in and steal the device from the table next to him. You are long gone by the time he realizes it is missing.If you advanced by parleying with Nathan Wick:“All right, listen,” Nathan explains quietly. “Truth is, there probably is a safer way for us to open the device. This building holds many secrets; more than you could possibly know. But time is running thin, and Mr. Sanford wants it open by midnight. If you can open it before then, great. If not, well... If I were you, I wouldn’t be around it when we try to force it open.” He hands you the device and walks away, leaving you in silence." />
+        <property name="Level" value="3" />
+      </alternate>
+    </card>
+    <card id="c458c425-9802-44fa-8ee0-fd42381d42af" name="The Four Keys" size="HorizCard">
+      <property name="Card Number" value="203" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Objective – If investigators at the same location control the Puzzle Box, the α key, the β key, the γ key, and the δ key, advance." />
+      <alternate name="The Four Keys" size="HorizCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Though the box itself seems to fight you at every turn, with all four key components in your possession, you finally manage to piece together how to open the contraption. First, you twist and contort the box’s many mechanical devices until the image on its lid lines up perfectly with the diagram in your possession (γ). Next, you chant the Latin incantation inscribed on the small wooden plaque you found (β). It takes a few tries to get it right, but eventually you hear a click as the surface of the wooden container shifts and changes. A round indentation has appeared on the side of the box, matching the size of your mysterious black onyx coin (δ). As soon as you place the coin inside, another wooden panel opens on the other side, revealing a keyhole. Finally, you insert the key of bone (α) into the keyhole and turn it. The lid begins to open, and suddenly the entirety of the room is engulfed in a rush of air as all light, color, sound, and matter is sucked into the box.Check Campaign Log. —If you are honorary members of the Lodge, (-&gt;R1).—If you are enemies of the Lodge, (-&gt;R2)." />
+      </alternate>
+    </card>
+    <card id="2cb4bbdf-869a-41a2-9e07-8f56caafbc56" name="Lodge Gates" size="EncounterCard">
+      <property name="Card Number" value="204" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="We've Been Expecting You" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <alternate name="Lodge Gates" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="We've Been Expecting You" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Text" value="Enemies cannot spawn at the Lodge Gates.η: Resign. On second thought, maybe coming here was a bad idea." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="a272bb4a-f6e3-4d08-9db7-ba0c2c79a9e0" name="Lodge Gates" size="EncounterCard">
+      <property name="Card Number" value="205" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="Members Only" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <alternate name="Lodge Gates" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="Members Only" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Text" value="Enemies cannot spawn at the Lodge Gates.η: Resign. On second thought, maybe coming here was a bad idea." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="941b7c4c-d30e-4ebe-b530-c4f740db0814" name="Lobby" size="EncounterCard">
+      <property name="Card Number" value="206" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="We've Been Expecting You" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <property name="Text" value="The entrance to the Silver Twilight Lodge is guarded. You cannot enter the Lobby.Lodge Gates gains: “η: Parley. The guards recognize you from the Meiger estate and let you pass. Reveal the Lobby.”" />
+      <alternate name="Lobby" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="We've Been Expecting You" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="28fd06e0-798c-4be0-99c8-2484938f4acf" name="Lobby" size="EncounterCard">
+      <property name="Card Number" value="207" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="Members Only" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <alternate name="Lobby" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="Members Only" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Text" value="Forced – After the Lobby is revealed: Place 1 random set-aside key on it." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="678f12f3-b7cb-4afe-96cb-fc5e29bcfeb9" name="Lodge Cellar" size="EncounterCard">
+      <property name="Card Number" value="208" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="We've Been Expecting You" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <alternate name="Lodge Cellar" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="We've Been Expecting You" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Text" value="Forced – After the Lodge Cellar is revealed: Place 1 random set-aside key on it." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="29c9979d-08c7-4b46-8f4d-3882710b4dac" name="Lodge Cellar" size="EncounterCard">
+      <property name="Card Number" value="209" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="Members Only" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <property name="Text" value="The rear entrance to the Silver Twilight Lodge is hidden. You cannot enter the Lodge Cellar.Lodge Gates gains: “η Investigators at the Lodge Gates spend 1π clues, as a group: Reveal the Lodge Cellar.&quot;" />
+      <alternate name="Lodge Cellar" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="Members Only" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="d31e3e02-9b3b-476e-b37f-80a80480c6bd" name="Lounge" size="EncounterCard">
+      <property name="Card Number" value="210" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <alternate name="Lounge" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Text" value="Forced – After the Lounge is revealed: Put the set-aside Vault and Library locations into play. Put the set-aside August Lindquist asset into play in the Lounge. Place 1 random set-aside key on him." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="2π" />
+      </alternate>
+    </card>
+    <card id="64ed2a25-81dd-4889-9b41-f25796cdb361" name="Vault" size="EncounterCard">
+      <property name="Card Number" value="211" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <property name="Text" value="The door to the Vault is locked. You cannot enter the Vault unless you control the δ key." />
+      <alternate name="Vault" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Text" value="Forced – After the Vault is revealed: Place 1 random set-aside key on it." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="d1b5a0e2-82df-4b8e-b96d-67c5f446c986" name="Library" size="EncounterCard">
+      <property name="Card Number" value="212" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge." />
+      <alternate name="Library" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge." />
+        <property name="Text" value="While you are investigating the Library, if you control the γ key, the Library gets –3 shroud." />
+        <property name="Shroud" value="6" />
+        <property name="Clues" value="1π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="0c55379a-9551-4b0b-a26e-dee84a2f4723" name="Lodge Catacombs" size="EncounterCard">
+      <property name="Card Number" value="213" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge. Sanctum." />
+      <property name="Text" value="The door to the catacombs is locked. You cannot enter the Lodge Catacombs unless you control at least 1 (α/β/γ/δ) key." />
+      <alternate name="Lodge Catacombs" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge. Sanctum." />
+        <property name="Text" value="Forced – When Lodge Catacombs is revealed: Put the set-aside Inner Sanctum and each of the set-aside Sanctum Doorway locations into play." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="d54c32cd-45e6-4bf2-b4cf-66769783ec78" name="Sanctum Doorway" size="EncounterCard">
+      <property name="Card Number" value="214" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge. Sanctum." />
+      <alternate name="Ceremony Room" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge. Sanctum." />
+        <property name="Text" value="Forced – When the round ends: Each investigator and each Ally asset in the Ceremony Room takes 1 direct horror. Cancel this effect if an investigator in the Ceremony Room controls the α key." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="2" />
+      </alternate>
+    </card>
+    <card id="9aecb0e7-3275-425b-95f8-99be1a99621d" name="Sanctum Doorway" size="EncounterCard">
+      <property name="Card Number" value="215" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge. Sanctum." />
+      <alternate name="Holding Cells" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge. Sanctum." />
+        <property name="Text" value="Forced – After Holding Cells is revealed: Search the encounter deck and discard pile for a Cultist enemy and spawn it in the Holding Cells. Shuffle the encounter deck." />
+        <property name="Shroud" value="1" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="769f425e-cbbe-4f6d-97d4-85780c69730a" name="Inner Sanctum" size="EncounterCard">
+      <property name="Card Number" value="216" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Lodge. Sanctum." />
+      <property name="Text" value="The door to the Inner Sanctum is locked. You cannot enter the Inner Sanctum unless you control the β key." />
+      <alternate name="Inner Sanctum" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Lodge. Sanctum." />
+        <property name="Text" value="Forced – After the Inner Sanctum is revealed: Place 1 random set-aside key on it." />
+        <property name="Combat" value="3" />
+        <property name="Agility" value="4" />
+        <property name="Unique" value="*" />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="d060ab82-c7c4-4154-b76a-e1f881a01159" name="Nathan Wick" size="EncounterCard">
+      <property name="Card Number" value="217" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="Master of Initiation" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Silver Twilight. Elite." />
+      <property name="Text" value="Retaliate.η: Parley. Test [ά] (3) to persuade Nathan to let you find another option. If you succeed, place 1 resource on Nathan Wick. Then, if there are 1π resources on him, add him to the victory display. If you fail, Nathan Wick attacks you." />
+      <property name="Health" value="5" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="3" />
+      <property name="Unique" value="*" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <property name="Victory Points" value="1" />
+      <alternate name="Nathan Wick" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="Master of Indoctrination" />
+        <property name="Type" value="Enemy" />
+        <property name="Traits" value="Humanoid. Cultist. Silver Twilight. Elite." />
+        <property name="Text" value="Alert.Forced – After you evade Nathan Wick by 3 or more: You steal the puzzle box. Add Nathan Wick to the victory display." />
+        <property name="Health" value="5" />
+        <property name="Damage" value="1" />
+        <property name="Horror" value="1" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="781b618f-5555-4688-be9f-2f37e40dde5b" name="Lodge Jailor" size="EncounterCard">
+      <property name="Card Number" value="218" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Silver Twilight." />
+      <property name="Text" value="Spawn – Any Sanctum location.Aloof.Forced – After Lodge Jailor enters play: Place 2 doom and 1 random set-aside key on it.η: Parley. Test [έ] (3). If you succeed, either remove 1 doom from Lodge Jailor, or take control of its key." />
+      <property name="Health" value="3" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="3" />
+      <property name="Horror" value="2" />
+    </card>
+    <card id="d8483e0d-5b23-4214-97c1-dbc4249c384a" name="Cell Keeper" size="EncounterCard">
+      <property name="Card Number" value="219" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Silver Twilight." />
+      <property name="Text" value="Spawn – Any Sanctum location.Alert.Forced – After Cell Keeper enters play: Place 2 doom and 1 random set-aside key on it.Forced – When you evade Cell Keeper by 2 or more: Take control of its key." />
+      <property name="Health" value="3" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="2" />
+      <property name="Horror" value="2" />
+    </card>
+    <card id="91f8f06a-b8f8-4a6e-ab6b-3a42236d3d28" name="Summoned Beast" size="EncounterCard">
+      <property name="Card Number" value="220" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="Guardian of the Trap" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Silver Twilight. Elite." />
+      <property name="Text" value="Retaliate. Hunter.Summoned Beast gets +1 fight, +1 evade, +1 damage, and +1 horror for every 2 doom in play.Forced – At the start of the enemy phase: Summoned Beast defeats each Humanoid enemy at its location. Move all doom from each of those enemies to Summoned Beast.Objective – If the Summoned Beast is defeated, (→R3)" />
+      <property name="Health" value="6π" />
+      <property name="Combat" value="5" />
+      <property name="Agility" value="2" />
+      <property name="Damage" value="2" />
+      <property name="Horror" value="2" />
+      <property name="Victory Points" value="2" />
+    </card>
+    <card id="f4eb7915-243a-48e4-9aef-a0397687f600" name="Knight of the Inner Circle" size="EncounterCard">
+      <property name="Card Number" value="221" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Silver Twilight." />
+      <property name="Text" value="Spawn – Any location connected to yours.Prey – Most (α/β/γ/δ) keys controlled.Alert. Aloof. Hunter.Forced – After you enter Knight of the Inner Circle’s location (or vice-versa): Test [ί] (4). If you fail, Knight of the Inner Circle engages you." />
+      <property name="Health" value="4" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="2" />
+      <property name="Damage" value="2" />
+    </card>
+    <card id="f526eda8-9504-45d8-a710-f7b3279119fc" name="Knight of the Outer Void" size="EncounterCard">
+      <property name="Card Number" value="222" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Silver Twilight." />
+      <property name="Text" value="Spawn – Any location connected to yours.Aloof. Peril. Retaliate.Revelation – After Knight of the Outer Void spawns, place either 1 or 2 doom on it.η: Parley. Test [ά] or [έ] (4). If you succeed, take control of 1 doom on Knight of the Outer Void, and flip it to its clue side. If you fail, Knight of the Outer Void attacks you." />
+      <property name="Health" value="3" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="4" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="093c9a1a-a87d-4cdc-8832-824be87b0f07" name="Call to Order" size="EncounterCard">
+      <property name="Card Number" value="223" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Scheme." />
+      <property name="Text" value="Revelation – Find the 2 topmost Cultist enemies in the encounter discard pile and spawn them in the empty location with the most remaining clues. If no Cultist enemies are spawned by this effect, Call to Order gains surge." />
+    </card>
+    <card id="d2c08b5e-afe7-44b3-81ab-26ec0866d3d3" name="Expulsion" size="EncounterCard">
+      <property name="Card Number" value="224" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Scheme." />
+      <property name="Text" value="Revelation – If there are no Cultist enemies in play, Expulsion gains surge. Otherwise, the nearest Cultist enemy readies, moves (one location at a time) until it reaches your location, engages you, and makes an immediate attack. Then, place each (α/β/γ/δ) key you control on that enemy." />
+    </card>
+    <card id="d0d83800-414d-4913-b66f-78b9f8dce82c" name="Beneath the Lodge" size="EncounterCard">
+      <property name="Card Number" value="225" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Scheme." />
+      <property name="Text" value="If you control at least 1 (α/β/γ/δ) key, Beneath the Lodge gains peril and its skill test gets +1 difficulty.Revelation – Test [έ] (3). For each point you fail by, you must either lose 1 clue or take 1 horror." />
+    </card>
+    <card id="16a55402-d8cc-4d8a-ac73-11301f6ec9c3" name="Mark of the Order" size="EncounterCard">
+      <property name="Card Number" value="226" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Scheme." />
+      <property name="Text" value="Surge.Revelation – Check which investigator controls each key. Otherwise, the investigator who controls:–the α key takes 1 damage.–the β key takes 1 horror.–the γ key discards 2 random cards from hand.–the δ key loses 3 resources." />
+    </card>
+    <card id="5244c3f2-2039-4f6d-a49d-a00eb4c9b370" name="August Lindquist">
+      <property name="Card Number" value="227" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="Elegant and Elusive" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Cultist. Silver Twilight." />
+      <property name="Text" value="η If investigators at August Lindquist’s location spend 2π clues, as a group: Parley. Each investigator who spent at least 1 clue must either take 1 damage or 1 horror. Remove August Lindquist from the game and take control of his key." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="–" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="" />
+    </card>
+    <card id="c9ff7c61-70ef-4cf3-8776-41c5f2550c7b" name="Puzzle Box">
+      <property name="Card Number" value="228" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="Mysterious Device" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Relic." />
+      <property name="Text" value="Forced – When you are defeated: Give control of the Puzzle Box to another investigator.η: Unlight a brazier at your location, exhaust The Spectral Watcher, or deal 5 damage to The Spectral Watcher if it is exhausted. This action does not provoke attacks of opportunity from The Spectral Watcher. (Group limit once per game.)" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="" />
+    </card>
+  </cards>
+</set>

--- a/o8g/Sets/For the Greater Good/set.xml
+++ b/o8g/Sets/For the Greater Good/set.xml
@@ -197,7 +197,7 @@
       <property name="Text" value="Forced – When you defeat a Silver Twilight enemy: You leave behind some evidence of the scuffle. Move 1 doom from each enemy at that location to the current agenda." />
       <property name="Level" value="2" />
       <property name="Doom" value="8" />
-      <alternate name="THE HIEROPHANT · V" size="HorizCard" type="B">
+      <alternate name="Meeting of Minds" size="HorizCard" type="B">
         <property name="Encounter Set" value="For the Greater Good" />
         <property name="Type" value="Agenda" />
         <property name="Text" value="As you explore the building, you almost wander into a heated debate between several members of the Lodge in a nearby hallway. Seeing an opportunity to learn more, you hide and eavesdrop on the conversation. “Mr. Sanford’s orders are to complete the geist-trap at any cost,” one of them says firmly. “If that means we must put lives in danger, so be it. The good of the many outweigh the good of the few; you know this.”Another member, a woman, pounds her fist on the wall. “No! Our first resort cannot be to spill blood. There must be another way.”“There is no time,” the other responds, and there is a murmur of agreement among the rest. “It is clear you do not have the will to proceed. Take her away. We will make her see for herself the sacrifices that must be made for the greater good.”“No! You can’t do this!” the woman yells. You wince as her screams echo down the corridor. What are they planning to do?Discard the top 5 cards of the encounter deck. In player order, each investigator must draw a Cultist enemy discarded in this way." />
@@ -212,7 +212,7 @@
       <property name="Text" value="Each Silver Twilight enemy in a Sanctum location loses aloof.Forced – When you defeat a Silver Twilight enemy: You leave behind some evidence of the scuffle. Move 1 doom from each enemy at that location to the current agenda." />
       <property name="Level" value="1" />
       <property name="Doom" value="10" />
-      <alternate name="Ends and Means" size="HorizCard" type="B">
+      <alternate name="The Greater Good" size="HorizCard" type="B">
         <property name="Encounter Set" value="For the Greater Good" />
         <property name="Type" value="Agenda" />
         <property name="Text" value="Revelation – Replace the act and agenda decks with The Greater Good. Spawn the set-aside Summoned Beast at the Puzzle Box’s location (or any Sanctum location if the Puzzle Box is not in play) and remove the Puzzle Box from the game." />
@@ -226,7 +226,7 @@
       <property name="Type" value="Act" />
       <property name="Level" value="1" />
       <property name="Doom" value="3π" />
-      <alternate name="Warm Welcome" size="HorizCard" type="B">
+      <alternate name="The Initiation" size="HorizCard" type="B">
         <property name="Encounter Set" value="For the Greater Good" />
         <property name="Type" value="Act" />
         <property name="Text" value="“Ah, it’s you.” You are approached by a member of the Lodge whom you recognize: one of Carl Sanford’s bodyguards from your previous meeting with the president. “I regret to inform you that Mr. Sanford and the other members of the Lodge are busy with an important task at the moment. I would suggest you come back at a later time.” You tell the man that your task is important, and offer to help in return for a meeting with Mr. Sanford. He considers you for a moment, then nods. “All right. We are attempting to open a device which we believe will help us bind the revenant you encountered earlier. You’ll want to speak with Nathan Wick if you want to help. You can find him in the library upstairs.” You thank him and turn to leave, but he grabs your arm and stops you, adding one final warning: “You should know that we intend to open this device at any cost. If you cannot stomach the consequences, once again, I suggest you leave.”If the Library is not in play, put it into play.Spawn the set-aside Nathan Wick enemy in the Library, (Master of Initiation) side faceup. Attach the set-aside Puzzle Box story asset to him." />
@@ -241,7 +241,7 @@
       <property name="Text" value="ι After you evade an enemy: Remove all doom from it." />
       <property name="Level" value="2" />
       <property name="Doom" value="2π" />
-      <alternate name="Infiltrating the Lodge" size="HorizCard" type="B">
+      <alternate name="The Indoctrination" size="HorizCard" type="B">
         <property name="Encounter Set" value="For the Greater Good" />
         <property name="Type" value="Act" />
         <property name="Text" value="At first, your investigation yields few answers. There is indeed a meeting of some sort happening at the manor tonight, though you’re not sure why. Finally, you catch a break. On a nearby table, a written summons explains the reason for tonight’s gathering:“Our timetable has moved forward. We must complete the trap by midnight tonight. The device we found will aid us in binding the revenant, so it is imperative that we find a way to open it before the ceremony begins. We have no time to waste with prudence or cowardice. Report to Nathan Wick in the sanctum at once.”You are left with more questions than answers.If the Inner Sanctum is not in play, put it into play.Spawn the set-aside Nathan Wick enemy in the Inner Sanctum, (Master of Indoctrination) side faceup. Attach the set-aside Puzzle Box story asset to him.For the remainder of the game, the current act gains “ι After you evade an enemy: Remove all doom from it.” Place this card next to the act deck as a reminder, then advance to act 2a." />
@@ -255,7 +255,7 @@
       <property name="Type" value="Act" />
       <property name="Text" value="Objective – If Nathan Wick is added to the victory display by any means, choose an investigator to take control of the attached Puzzle Box, and advance." />
       <property name="Level" value="3" />
-      <alternate name="Obtaining the Device" size="HorizCard" type="B">
+      <alternate name="The Puzzle Box" size="HorizCard" type="B">
         <property name="Encounter Set" value="For the Greater Good" />
         <property name="Type" value="Act" />
         <property name="Text" value="If you advanced by defeating Nathan Wick:You quickly pry the device from Nathan’s hands and flee before you are noticed.If you advanced by evading Nathan Wick:You wait until Nathan is not looking, then sweep in and steal the device from the table next to him. You are long gone by the time he realizes it is missing.If you advanced by parleying with Nathan Wick:“All right, listen,” Nathan explains quietly. “Truth is, there probably is a safer way for us to open the device. This building holds many secrets; more than you could possibly know. But time is running thin, and Mr. Sanford wants it open by midnight. If you can open it before then, great. If not, well... If I were you, I wouldn’t be around it when we try to force it open.” He hands you the device and walks away, leaving you in silence." />
@@ -268,7 +268,7 @@
       <property name="Encounter Set" value="For the Greater Good" />
       <property name="Type" value="Act" />
       <property name="Text" value="Objective – If investigators at the same location control the Puzzle Box, the α key, the β key, the γ key, and the δ key, advance." />
-      <alternate name="The Four Keys" size="HorizCard" type="B">
+      <alternate name="Opening the Box" size="HorizCard" type="B">
         <property name="Encounter Set" value="For the Greater Good" />
         <property name="Type" value="Act" />
         <property name="Text" value="Though the box itself seems to fight you at every turn, with all four key components in your possession, you finally manage to piece together how to open the contraption. First, you twist and contort the box’s many mechanical devices until the image on its lid lines up perfectly with the diagram in your possession (γ). Next, you chant the Latin incantation inscribed on the small wooden plaque you found (β). It takes a few tries to get it right, but eventually you hear a click as the surface of the wooden container shifts and changes. A round indentation has appeared on the side of the box, matching the size of your mysterious black onyx coin (δ). As soon as you place the coin inside, another wooden panel opens on the other side, revealing a keyhole. Finally, you insert the key of bone (α) into the keyhole and turn it. The lid begins to open, and suddenly the entirety of the room is engulfed in a rush of air as all light, color, sound, and matter is sucked into the box.Check Campaign Log. —If you are honorary members of the Lodge, (-&gt;R1).—If you are enemies of the Lodge, (-&gt;R2)." />

--- a/o8g/Sets/Guardians of the Abyss/set.xml
+++ b/o8g/Sets/Guardians of the Abyss/set.xml
@@ -1,0 +1,813 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<set gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" id="ce3f5fac-f9cf-49e8-86db-52be4274bc8e" name="Guardians of the Abyss" standalone="True" version="1.0.0" xmlns:noNamespaceSchemaLocation="CardSet.xsd">
+  <cards>
+    <card id="d75b87c4-c7ed-4b63-a22c-26b53ce329b1" name="The Eternal Slumber" size="EncounterCard">
+      <property name="Card Number" value="1" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Subtitle" value="EASY / STANDARD" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –X. X is the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.γ: 0. For this skill test, ignore any effect that would increase your skill value.δ: –5. You may add 1 strength to the abyss to automatically succeed, instead.Strength of the Abyss:" />
+      <alternate name="The Eternal Slumber" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Subtitle" value="HARD / EXPERT" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –X. X is 1 more than the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.γ: –2. For this skill test, ignore any effect that would increase your skill value.δ: –6. You may add 1 strength to the abyss to automatically succeed, instead.Strength of the Abyss:" />
+      </alternate>
+    </card>
+    <card id="46f53b5c-30ec-49f6-b9a3-a985bf61d11b" name="Museum of Egyptian Antiquities" size="EncounterCard">
+      <property name="Card Number" value="10" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Cairo." />
+      <alternate name="Museum of Egyptian Antiquities" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Cario." />
+        <property name="Text" value="η: Test έ (5). If you succeed, remember that you have “discovered an ancient tablet.”Forced – After you investigate Museum of Egyptian Antiquities, if you did not succeed by at least 2: Lose all remaining actions and immediately end your turn." />
+        <property name="Shroud" value="1" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="f3f9f4c2-2d2a-43f4-abaf-fe22fa3fa661" name="Outskirts of Cairo" size="EncounterCard">
+      <property name="Card Number" value="11" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Cairo." />
+      <alternate name="Outskirts of Cairo" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Cairo." />
+        <property name="Text" value="η Choose and discard 5 cards from your hand: Remember that you have “sabotaged the train.”η If no investigator has “sabotaged the train”: Resign. You take the train out of Cairo, leaving the dreamers to their unceasing nightmare." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="244db7a4-79c5-4b44-a3e1-8c367f6448fc" name="Temple Courtyard" size="EncounterCard">
+      <property name="Card Number" value="12" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Cairo." />
+      <alternate name="Temple Courtyard" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Cairo." />
+        <property name="Text" value="While there are no clues remaining on Temple Courtyard, each copy of Humble Supplicant loses aloof.η: Test ή (5). If you succeed, remember that you have “broken into an abandoned temple.”" />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="ba44ac48-e286-4f18-aac0-a06dcb16842d" name="Neith" size="EncounterCard">
+      <property name="Card Number" value="13" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Subtitle" value="Harbinger of the Abyss" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Brotherhood. Elite." />
+      <property name="Text" value="Hunter. Retaliate.Forced – After horror from Neith’s attack defeats an investigator or Ally asset: That card is “taken by the abyss.”Forced – When Neith is dealt any amount of damage from an attack, if there is at least 1 dreamer at her location: Remove 1 dreamer from her location and cancel 1 damage just dealt to Neith." />
+      <property name="Health" value="5π" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="4" />
+      <property name="Unique" value="ο" />
+      <property name="Horror" value="2" />
+      <property name="Victory Points" value="1" />
+    </card>
+    <card id="eb866de6-adfd-477c-9497-4d7c018fb6fc" name="Humble Supplicant" size="EncounterCard">
+      <property name="Card Number" value="14" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist." />
+      <property name="Text" value="Spawn – Any Cairo location (with a Brotherhood enemy, if able).Aloof.Each Brotherhood enemy at Humble Supplicant’s location cannot be attacked or damaged.Forced – When the enemy phase ends: Move Humble Supplicant once toward the nearest Brotherhood enemy, if able." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="2" />
+      <property name="Damage" value="1" />
+    </card>
+    <card id="55a4cdfe-8f94-40db-8b56-a979a60b0bc3" name="Creature from the Abyss" size="EncounterCard">
+      <property name="Card Number" value="15" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Dreamlands." />
+      <property name="Text" value="Retaliate.X is the strength of the abyss.Forced – After Creature from the Abyss enters play, if the strength of the abyss is 2 or lower: Add 1 strength to the abyss.Forced – After Creature from the Abyss is defeated, if the strength of the abyss or 5 or higher: Remove 1 strength from the abyss." />
+      <property name="Health" value="3" />
+      <property name="Combat" value="X" />
+      <property name="Agility" value="3" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="879846b9-e547-4c81-8119-ad8974e02798" name="The Night’s Usurper" size="EncounterCard">
+      <property name="Card Number" value="16" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –X. X is the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.γ: –1. For this skill test, ignore any effect that would increase your skill value.δ: –4. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss.Strength of the Abyss:" />
+      <alternate name="The Night’s Usurper" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –X. X is 1 more than the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.γ: –3. For this skill test, ignore any effect that would increase your skill value.δ: –5. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss.Strength of the Abyss:" />
+      </alternate>
+    </card>
+    <card id="74e12e40-655d-4475-b829-3d2feae1b6a5" name="The Brotherhood Bides Their Time" size="HorizCard">
+      <property name="Card Number" value="17" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Agenda" />
+      <property name="Level" value="1" />
+      <property name="Doom" value="6" />
+      <alternate name="The Brotherhood's Revenge!" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="Having found the perfect moment to strike, the remaining members of the Brotherhood ambush you in the night. “For Nephren-Ka! For Xzharah!” they cry out in exultation as they surround your camp. Their eyes are burning red with unnatural power, their muscles bulging and their veins pulsing with bizarre fluid. Nothing you say deters their attack, and you wonder if there is any humanity left in their minds at all.In player order, each investigator takes a random Brotherhood enemy from under the scenario reference card and spawns it engaged with him or her, until either each of the enemies under the scenario reference card have been spawned, or each investigator has spawned an enemy in this way. Spawn each enemy still remaining under the scenario reference card, one at a time, at empty locations farthest from the Expedition Camp. (Ignore all “Spawn” instructions on those enemies.)Shuffle the encounter discard pile into the encounter deck.Add 1 strength to the abyss." />
+        <property name="Level" value="1" />
+      </alternate>
+    </card>
+    <card id="53072c63-caa4-4d1b-b602-d6748c68a4f3" name="Schemes in the Dark Beyond" size="HorizCard">
+      <property name="Card Number" value="18" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Investigators cannot Parley with Brotherhood enemies. Each Brotherhood enemy cannot be flipped over.Forced – After the 4th or 8th doom is placed on this agenda: Add 1 strength to the abyss." />
+      <property name="Level" value="2" />
+      <property name="Doom" value="12" />
+      <alternate name="A Prophecy Fulfilled" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="“It is done.” Xzharah plunges his blade into the last of the dreamers. Its starry surface, soaked in hot crimson blood, devours the victim’s life force. “With this soul, I am complete.”The abyss is plunged into a dreadful silence. None can question the authority and power of the realm’s new lord. Uncouth creatures of darkness crawl forth from their pits to pay tribute to their master. As Xzharah surveys his domain, the mist coils about his feet with each step he takes. Countless winged creatures bow in servitude as he passes.This world is his. Ours is next.Each investigator is defeated.Each defeated investigator is “taken by the abyss.”(-&gt;R1)" />
+        <property name="Level" value="2" />
+      </alternate>
+    </card>
+    <card id="d54f38db-9a1e-4ef2-8d64-d5b6f4c0dcfc" name="Search for the Gate" size="HorizCard">
+      <property name="Card Number" value="19" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="η: Explore. Draw the top card of the exploration deck. If it is a connecting location, put it into play and move to it." />
+      <property name="Level" value="1" />
+      <property name="Clues" value="2π" />
+      <alternate name="Construct of the Ancients" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="It has been several weeks since you set forth from Cairo, but to your dismay, you have found no sign of the otherworldly gate to which the Brotherhood supposedly retreated. Just as you are considering returning to Cairo to conduct more research, you are summoned into Winlock’s tent, where the weary expedition leader is examining a map of Egypt with calloused hands. “Oh good, you’re here,” he says, fumbling through his pack for an old, half-burned tome, which he places on the table in front of you. “Thought you might want to see what we found in that crypt to the south.” You turn over the book, sifting through its charred pages, until you come to a map of the desert marked by Egyptian hieroglyphs. It is the same region depicted on the map in front of Winlock. “See that, right there?” He points to one of the hieroglyphs on the western side of the map. “It means ‘door’.” With a hint of a smirk, he then points to the same spot on his larger map, marking your destination.“That what you’re looking for?”Shuffle the set-aside Eldritch Gate into the exploration deck." />
+        <property name="Level" value="1" />
+      </alternate>
+    </card>
+    <card id="c550a922-9c5f-4a6b-bab7-57c6726716fd" name="Jessie’s Request" size="HorizCard">
+      <property name="Card Number" value="2" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="η Investigators spend 1[per investigator] clues, as a group: Randomly spawn one of the enemies beneath the scenario reference card." />
+      <property name="Level" value="1" />
+      <property name="Doom" value="7" />
+      <alternate name="They're on to You" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="You’ve found enough leads to confirm the existence of a shadowy organization within Cairo, and perhaps the origin of the curse afflicting the city. However, despite your best efforts, the secret cabal has vanished from the city without a trace. You’re going to need a lot more information if you are to cure this illness.Find each Brotherhood enemy currently in play (at a location or in an investigator’s threat area). Place each of those enemies beneath the scenario reference card, out of play.Shuffle each set-aside copy of Abyssal Revenant into the encounter deck, along with the encounter discard pile.Add 1 strength to the abyss.If it is act 1, advance the current act." />
+        <property name="Level" value="1" />
+      </alternate>
+    </card>
+    <card id="94a8e53e-27e1-4fa4-9e57-1271d441d187" name="Into the Gate" size="HorizCard">
+      <property name="Card Number" value="20" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="η: Explore. Draw the top card of the exploration deck. If it is a connecting location, put it into play and move to it.Objective – At the end of the round, if each undefeated investigator is at the Eldritch Gate and they spend the requisite number of clues, advance." />
+      <property name="Level" value="2" />
+      <property name="Clues" value="1π" />
+      <alternate name="Delve into Dreams" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Reality slips away as you cross the threshold of the gate. The sandy dunes fold into the foundation of the Earth, the firmament splits, and the colors of the world bleed into the archway. When next you open your eyes, you are in a place between worlds. At the opposite end of the corridor, a figure emerges from the doorway beyond, faceless and wielding a curved blade that pulses with dark power. “You shall be my next sacrifice,” his voice seethes.Put the set-aside A Dream Betwixt location into play, revealed location side faceup. Move each investigator there and remove all other locations from the game. Spawn the set-aside Xzharah enemy in A Dream Betwixt, enemy side faceup. Shuffle each set-aside copy of Dreaded Shantak into the encounter deck, along with the encounter discard pile.If the Ancient Ankh asset is in play:Your Ankh amulet glows with a blinding light, causing Xzharah to recoil. “So, Neith has abandoned us!” Xzharah hisses.Exhaust Xzharah and disengage him from all investigators." />
+        <property name="Level" value="2" />
+      </alternate>
+    </card>
+    <card id="65c41f55-1d72-4052-8ea9-c5a2bcb330a5" name="The Night’s Usurper" size="HorizCard">
+      <property name="Card Number" value="21" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Objective – “We have to find a way to stop him!” If Xzharah is exhausted, an investigator at his location may choose to advance. (Limit once per phase.)" />
+      <property name="Level" value="3" />
+      <alternate name="Defeating Xzharah" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Xzharah cannot be stopped by means you alone possess. Perhaps if you learn more about the realm beyond the gateway, you can find a way to end this vile ritual.If at least three of the following requirements are met, you may proceed to (-&gt;R2). Otherwise, flip this act back to its “a” side.—Xzharah must have no remaining health.—Investigators must possess 3[per investigator] clues, as a group.—The strength of the abyss must be 4 or lower.—The investigators must have “freed the nightgaunts,” “warned the denizens of Sarkomand,” and “pled for help.”" />
+        <property name="Level" value="3" />
+      </alternate>
+    </card>
+    <card id="766a822a-c927-4faf-b1c1-1b5cce3a8d10" name="A Dream Betwixt" size="EncounterCard">
+      <property name="Card Number" value="22" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld. Extradimensional." />
+      <property name="Text" value="Forced – If the strength of the abyss is 0: Set the strength of the abyss to 1.ι After you successfully investigate A Dream Betwixt: Flip it over and resolve the text on its other side." />
+      <property name="Shroud" value="4" />
+      <property name="Clues" value="0" />
+      <alternate name="To the Dreamlands" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="The gateway beyond this corridor leads to a place beyond the physical world. A place where dreams and reality converge. You steady your thoughts and stare into the abyss. The abyss embraces you.Put each of the remaining set-aside locations into play, revealed location side faceup—The Great Abyss, Tunnels under Ngranek, Stairway to Sarkomand, and Mist-Filled Caverns. (Place clues on each of those locations equal to their clue value.)The investigator resolving this text disengages from each engaged enemy and moves to The Great Abyss.Flip this card back over. For the remainder of the game, it cannot be flipped over again." />
+      </alternate>
+    </card>
+    <card id="154eac12-b7ef-406a-a3dc-a51f81cb7b20" name="The Great Abyss" size="EncounterCard">
+      <property name="Card Number" value="23" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld. Dreamlands." />
+      <property name="Text" value="ι After you discover the last remaining clue from The Great Abyss: Flip it over and resolve the text on its other side.Victory 1." />
+      <property name="Shroud" value="5" />
+      <property name="Clues" value="1π" />
+      <property name="Victory Points" value="1" />
+      <alternate name="Fate of the Dreamers" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="As you traverse the vast abyss, you are surprised to find others wandering through the cavernous mist, mesmerized and confused. You don’t recognize them as patients from the incident in Cairo. The Brotherhood must have sent these victims here recently. With the knowledge you have now, you could try to awaken them—or guide them to Xzharah as sacrifices.You must decide (choose one):–Remove 2 strength from the abyss.–Add 2 strength to the abyss.Regardless of your choice, flip this card back over. For the remainder of the game, it cannot be flipped over again." />
+      </alternate>
+    </card>
+    <card id="66a80678-c5ed-48e8-9029-df6ecb33247b" name="Tunnels under Ngranek" size="EncounterCard">
+      <property name="Card Number" value="24" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld. Dreamlands." />
+      <property name="Text" value="η: Test έ (2) to search for signs of life within these jagged tunnels. If you succeed, flip this location over and resolve the text on its other side." />
+      <property name="Shroud" value="2" />
+      <property name="Clues" value="1π" />
+      <alternate name="Prisoners of Conquest" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="As you explore the volcanic tunnels, you find the brutalized corpses of dozens of winged creatures: some black and faceless, with membranous wings and dark horns; others huge and scaly, with bat-like wings and heads like a horse's. Continuing deeper down the tunnels, you come across more of the faceless creatures restrained by thick iron chains. Prisoners of Xzharah, you imagine. They make no sound as you approach, their uncanny heads turning towards you.You must decide (choose one):–Test ί (4) to free the creatures. If you succeed, one of them hands you 3 black whistles before they fly off toward their master; take control of the set-aside Summoned Nightgaunt asset and remember that you “freed the nightgaunts.”–Test ή (4) to slay the creatures. If you succeed, remember that you “executed the nightgaunts.”Regardless of your choice and whether you succeed or fail the indicated skill test, flip this card back over." />
+      </alternate>
+    </card>
+    <card id="c0b5e8c9-477d-43b2-9eb8-467e08cd758a" name="Stairway to Sarkomand" size="EncounterCard">
+      <property name="Card Number" value="25" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld. Dreamlands." />
+      <property name="Text" value="η: Test ά (3) to navigate the bewildering and gravity-defying staircase. If you succeed, flip this location over and resolve the text on its other side." />
+      <property name="Shroud" value="3" />
+      <property name="Clues" value="1π" />
+      <alternate name="Ruins of Sarkomand" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="After what feels like an eternity, you finally reach the top of the subterranean stairs, where a trapdoor leads you to the surface. You find yourself in the large central plaza of a ruined city on the shoreline of a beautiful sky-blue ocean. A pair of colossal winged lion statues guards the entrance to the stairway.You must decide (choose one):–Test έ (3) to speak to the almost-humanoid creatures that dwell in these ruins. If you succeed, you warn them of the battle below and they flee; remember that you “warned the denizens of Sarkomand.”–Test ή (3) to block the trapdoor. If you succeed, you topple the lion statues and use them to block the entrance to the stairway as you descend back into the depths; remember that you “cut off all escape.”Regardless of your choice and whether you succeed or fail the indicated skill test, flip this card back over." />
+      </alternate>
+    </card>
+    <card id="5b9fd7fb-e348-4a84-8ee0-8b5a8b413846" name="Mist-Filled Caverns" size="EncounterCard">
+      <property name="Card Number" value="26" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Otherworld. Dreamlands." />
+      <property name="Text" value="η: Test ί (4) to traverse through the mist. If you succeed, flip this location over and resolve the text on its other side." />
+      <property name="Shroud" value="1" />
+      <property name="Clues" value="1π" />
+      <alternate name="Effigy of Nodens" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="The mist grows ever thicker as you make your way deeper into the depths of the abyss. Finally, you come across an open chamber where the mist has receded, and you are greeted by a tall statue of an elderly man with a great beard and a mane of long hair. He rides a chariot formed from a huge seashell, which is pulled by beasts both wondrous and strange.You must decide (choose one):–Test ά (2) to entreat the entity depicted in this statue for aid. If you succeed, remember that you “pled for help.”–Test ή (2) to overthrow the statue. If you succeed, it topples over and shatters into pieces on the jagged cavern floor; remember that you “affronted the ruler of this realm.”Regardless of your choice and whether you succeed or fail the indicated skill test, flip this card back over." />
+      </alternate>
+    </card>
+    <card id="ee6c2283-3de1-42c3-b5a5-242cebabf330" name="Xzharah" size="EncounterCard">
+      <property name="Card Number" value="27" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Subtitle" value="Chosen of the Beast" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Servitor. Dreamlands. Conspirator. Elite." />
+      <property name="Text" value="Hunter. Retaliate.Xzharah gets +5[per investigator] health and cannot be defeated by damage.η: Parley. Test ά or έ (X), where X is the strength of the abyss. If you succeed, flip this enemy over and resolve the text on its other side. If you fail, Xzharah attacks you." />
+      <property name="Health" value="5" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="4" />
+      <property name="Unique" value="ο" />
+      <property name="Damage" value="2" />
+      <property name="Horror" value="2" />
+      <alternate name="Usurp the Night" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="The Chosen One’s words are grim whispers that worm their way into your ears. “The Day of Nephren-Ka shall come, and the road shall be paved with blood,” he promises. “Prove your loyalty and you shall be rewarded. When the Day arrives, you alone shall be spared. Refuse, and be consumed. Then I alone shall rule this place.”If each of the following requirements are met, you may proceed to (-&gt;R3).—The strength of the abyss must be 5 or higher.—The investigators must have “executed the nightgaunts,” “cut off all escape,” and “affronted the ruler of this realm.”If the above requirements are not met, each investigator may choose whether or not to accept Xzharah’s mercy and immediately resign. If any investigators remain, flip this card back to its enemy side." />
+      </alternate>
+    </card>
+    <card id="c640bf96-f9c8-4f45-a60a-872d992eb8f1" name="Eldritch Gate" size="EncounterCard">
+      <property name="Card Number" value="28" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Desert. Ruins." />
+      <property name="Shroud" value="4" />
+      <property name="Clues" value="1π" />
+    </card>
+    <card id="6b903f61-70aa-4436-8985-d164cace2f70" name="Dreaded Shantak" size="EncounterCard">
+      <property name="Card Number" value="29" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Dreamlands. Shantak." />
+      <property name="Text" value="Hunter. Massive.While Dreaded Shantak is ready, η and ι abilities on its location cannot be triggered." />
+      <property name="Health" value="5" />
+      <property name="Combat" value="5" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="2" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="316af1a0-ffac-48d7-a4b9-f6c157327d49" name="Curse of the Abyss" size="HorizCard">
+      <property name="Card Number" value="3" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Forced – If the strength of the abyss is 0: Set the strength of the abyss to 1. Each investigator draws 1 card and heals 1 horror." />
+      <property name="Level" value="2" />
+      <property name="Doom" value="6" />
+      <alternate name="The Abyss Grows..." size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="As more and more fall victim to the curse that has infected Cairo, a silent terror grips the city. When night falls again, the streets are filled with a sudden panic. It starts with turmoil outside the hospital, as people demand to know what has happened to their loved ones and what the doctors are doing to solve the problem. Before long, rioting and looting erupt throughout the city. By midnight, the streets have descended into utter chaos.Shuffle the encounter discard pile into the encounter deck.Add 1 strength to the abyss." />
+        <property name="Level" value="2" />
+      </alternate>
+    </card>
+    <card id="72d4d7b8-2eac-4de9-9dd9-4a37183a1404" name="Speaker for the Dark Pharaoh" size="EncounterCard">
+      <property name="Card Number" value="30" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist." />
+      <property name="Text" value="While the strength of the abyss is 2 or lower, Speaker for the Dark Pharaoh gains hunter.Forced – After Speaker for the Dark Pharaoh is defeated, if the strength of the abyss is 3 or higher: Each investigator at its location takes 1 damage." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="3" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="586f9776-c2f6-468b-afff-63b625902eae" name="Dr. Layla El Masri" size="EncounterCard">
+      <property name="Card Number" value="31" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Brotherhood of the Beast" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
+      <property name="Text" value="Spawn – Expedition Camp.η As a group, investigators at Dr. Layla El Masri’s location discard cards from hand with a total of at least 4 ά icons among them: Parley. Add Dr. Layla El Masri to the victory display.Victory 1." />
+      <property name="Health" value="4" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="2" />
+      <property name="Unique" value="ο" />
+      <property name="Horror" value="2" />
+      <property name="Victory Points" value="1" />
+      <alternate name="The Translator’s Evidence" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Brotherhood of the Beast" />
+        <property name="Type" value="Story" />
+        <property name="Traits" value="Evidence." />
+        <property name="Text" value="“I didn’t have a choice!” Layla cries. “The things I’ve read... The records I’ve translated... They all point to one thing,” she claims. “Destruction. Ruin. We can’t stop it. All we can do is forge a place for our loved ones in the rubble.” You tell her that you will do everything in your power to stop this ‘destruction’, but she shakes her head, tears in her eyes. “It’s a fool’s errand. But...” Layla takes a deep breath as she considers her options. “Promise you’ll keep my daughter and my son safe, and I’ll help you in any way I can.”After an investigator has “discovered an ancient tablet,” read the following (if an investigator has already completed this task, read the following immediately):You bring the tablet to Dr. El Masri, and she translates it to the best of her ability. “When the Choice is made, He shall be empowered by a thousand sacrifices from the sacred land.” She blinks a few times, trying to process what it means. “How many coma patients are there right now?” she asks, wide-eyed.Remove 1 strength from the abyss. (Group limit once per game.)Victory 1." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="24eef006-8861-42ea-aa67-950288e1e1de" name="Dr. Wentworth Moore" size="EncounterCard">
+      <property name="Card Number" value="32" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Brotherhood of the Beast" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
+      <property name="Text" value="Spawn – Museum of Egyptian Antiquities.Dr. Wentworth Moore cannot be damaged while there is a ready Monster enemy at his location.Forced – After Dr. Wentworth Moore enters play: Search the encounter deck and discard pile for a Monster enemy, and spawn it at his location. Shuffle the encounter deck.Victory 1." />
+      <property name="Health" value="1" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="3" />
+      <property name="Unique" value="ο" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <property name="Victory Points" value="1" />
+      <alternate name="The Supplicant’s Evidence" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Brotherhood of the Beast" />
+        <property name="Type" value="Story" />
+        <property name="Traits" value="Evidence." />
+        <property name="Text" value="Despite your best efforts, Dr. Moore slips away while you are occupied by his ‘bodyguard’. With the creature defeated, and you hot on his trail, you suspect he will try to escape the city while he has the chance.————————————————————After an investigator has “sabotaged the train,” read the following (if an investigator has already completed this task, read the following immediately):You manage to corner Dr. Moore as he tries to escape the city on foot. “Very clever,” he admits. “But you’re already out of time. Lock me up, it doesn’t matter. The dreamers will be sacrificed, and our Chosen will lead us to a new age.” But after several hours, he is begging to be let out of the city. “Please, the reaper is coming! Neith is coming for us all. We’ll all be sacrificed, don’t you understand? You and me both! All of us need to flee the city while we still can!”Remove 1 strength from the abyss. (This effect can only be resolved once per game.)Victory 1." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="76f6e377-7192-4ed6-81a7-6c8852090f8f" name="Nadia Nimr" size="EncounterCard">
+      <property name="Card Number" value="33" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Brotherhood of the Beast" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
+      <property name="Text" value="Spawn – Temple Courtyard.η: Parley. Test ά (7). You may take up to 3 horror to reduce the difficulty of this test by 2 for each horror taken in this way. If you succeed, add Nadia Nimr to the victory display. If you fail, Nadia Nimr attacks you.Victory 1." />
+      <property name="Health" value="3" />
+      <property name="Combat" value="5" />
+      <property name="Agility" value="3" />
+      <property name="Unique" value="ο" />
+      <property name="Damage" value="2" />
+      <property name="Victory Points" value="1" />
+      <alternate name="The Priestess’s Evidence" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Brotherhood of the Beast" />
+        <property name="Type" value="Story" />
+        <property name="Traits" value="Evidence." />
+        <property name="Text" value="Nadia’s faith is shaken. Scared and confused, she finally gives in. “There is only one residence in Cairo they told us to spare,” she explains. “None of us know why, or what their connection is to the Brotherhood. All we know is they were not to be disturbed.” She hesitantly gives you a small brass key. “...So maybe it’s time to disturb them. The building’s door is marked with lamb’s blood.”————————————————————After an investigator has “found a door marked with blood,” read the following (if an investigator has already completed this task, read the following immediately):Using the key Nadia gave you, you enter the marked residence. To your surprise, there is nobody inside—only the faint stench of rot and aged leather. The basement of the residence is littered with old books, records kept by the Brotherhood and its many agents. They will take some time to peruse, but a lead is a lead.Remove 1 strength from the abyss. (Group limit once per game.)Victory 1." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="01a1356f-be9c-4cf2-94f8-544baa853d9f" name="Farid" size="EncounterCard">
+      <property name="Card Number" value="34" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Brotherhood of the Beast" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
+      <property name="Text" value="Spawn – Cairo Bazaar.η: Parley. Test έ (7). You may spend up to 5 resources to reduce the difficulty of this test by 1 for each resource spent in this way. If you succeed, add Farid to the victory display. If you fail, Farid attacks you.Victory 1." />
+      <property name="Health" value="4" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="2" />
+      <property name="Unique" value="ο" />
+      <property name="Damage" value="1" />
+      <property name="Victory Points" value="1" />
+      <alternate name="The Salesman’s Evidence" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Brotherhood of the Beast" />
+        <property name="Type" value="Story" />
+        <property name="Traits" value="Evidence." />
+        <property name="Text" value="“All right, all right,” Farid relents, “I’m a businessman, not a soldier. Strike a deal with me, and I’ll tell you what I know. Then I’ll skip out of town and be out of your hair.” You ask what he wants. “There’s a vault in the abandoned temple to the east. Word is, there are a lot of old, valuable artifacts in there. The kind that would fetch a high price on the black market.” He grins toothily.”Get me into that temple, and I’m all yours. Deal?”————————————————————After an investigator has “broken into a deserted temple,” read the following (if an investigator has already completed this task, read the following immediately):Farid grins wide as he scoops golden idols into his rucksack. You press him for information before he gets too excited. “Look, they promised me wealth beyond my wildest dreams. Even I have my price, you know?” He throws up his hands, resigned. “Let me show you my records. I’ve done a lot of ‘business’ in the last few months. That’ll point you in the right direction.”Remove 1 strength from the abyss. (Group limit once per game.)Victory 1." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="8728bd85-572a-4ec9-b518-6e2676f267eb" name="Nassor" size="EncounterCard">
+      <property name="Card Number" value="35" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Brotherhood of the Beast" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
+      <property name="Text" value="Spawn – Streets of Cairo.Retaliate.Forced – When Nassor attacks: Either add 1 strength to the abyss, or Nassor deals +1 damage and +1 horror for this attack (+2 damage and +2 horror instead if it is the enemy phase).Victory 1." />
+      <property name="Health" value="6" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="4" />
+      <property name="Unique" value="ο" />
+      <property name="Victory Points" value="1" />
+      <alternate name="The Assassin’s Evidence" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Brotherhood of the Beast" />
+        <property name="Type" value="Story" />
+        <property name="Traits" value="Evidence." />
+        <property name="Text" value="Despite his mortal wounds, the assassin grins wickedly. “The Day is coming,” he says between a fit of coughs. “You think killing me will stop it? Fools! The Beast will devour you all!” He cackles with his final breath, then falls silent.You are quick to search his belongings before any bystanders spot the body. Among the many strange curios on his person, you find a small leather-bound journal with a cryptic inscription:Our tribute soaks the abyssal bladeA thousand souls never to wakeWith this our Chosen shall ariseAnd the Day is ever nigh!Remove 1 strength from the abyss. (Group limit once per game.)Victory 1." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="9ebacd6c-7f37-4051-98ea-530141d18e30" name="Professor Nathaniel Taylor" size="EncounterCard">
+      <property name="Card Number" value="36" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Brotherhood of the Beast" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
+      <property name="Text" value="Spawn – Outskirts of Cairo.η As a group, investigators at Professor Nathaniel Taylor’s location discard cards from hand with a total of at least 4 έ icons among them: Parley. Add Professor Nathaniel Taylor to the victory display.Victory 1." />
+      <property name="Health" value="4" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="4" />
+      <property name="Unique" value="ο" />
+      <property name="Horror" value="1" />
+      <property name="Victory Points" value="1" />
+      <alternate name="The Professor’s Evidence" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Brotherhood of the Beast" />
+        <property name="Type" value="Story" />
+        <property name="Traits" value="Evidence." />
+        <property name="Text" value="“I’ll be dead soon anyway,” Professor Taylor admits with a deep sigh. “If it’s not you, or the Brotherhood, it’ll be the tumor in my lung.” He dumps the ashes in his pipe and sets it on his table before turning back towards you. “Fine. I’m certain it’ll be the death of both of us, but I’ll help you out. Don’t know what you expect from me, exactly. I suppose if you found one of the Brotherhood’s artifacts, I could study it for you.”————————————————————After an investigator has “bought an odd trinket,” read the following (if an investigator has already completed this task, read the following immediately):You set the trinket down on Professor Taylor’s desk. The elderly man puts on his monocle and examines it carefully. “Intriguing,” he says with an expression of surprise. “This could only have come from a particular tomb in the royal crypts of Dashur. One most scholars don’t believe exists.” He rises to his feet and shakes your hand. “Give me some time to study this further. Perhaps if we both make it out of this alive, I can resubmit my thesis,” he says with a morbid chuckle.Remove 1 strength from the abyss. (Group limit once per game.) Victory 1." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="c9035367-ebae-436e-9c7d-258c7a55baed" name="Expedition Camp" size="EncounterCard">
+      <property name="Card Number" value="37" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Cairo. Desert." />
+      <alternate name="Expedition Camp" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Sands of Egypt" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Expedition. Cairo. Desert." />
+        <property name="Text" value="η: Parley. Test έ (2) to speak to the researchers stationed here. If you succeed, look at the top X cards of either the exploration deck or the encounter deck, where X is the amount you succeeded by. Place up to 2 of those cards on the bottom of that deck. Place the rest on top in a random order. (Group limit once per round.)" />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="ac578029-0943-47e4-b3ed-8575726802c7" name="Nile River" size="EncounterCard">
+      <property name="Card Number" value="38" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Desert." />
+      <property name="Text" value="Forced – After you enter Nile River: You must either take 1 horror or discard 1 card from your hand at random." />
+      <property name="Shroud" value="2" />
+      <property name="Clues" value="1π" />
+    </card>
+    <card id="35c1b734-a07b-48b2-8534-183323cb0a42" name="Sands of Dashur" size="EncounterCard">
+      <property name="Card Number" value="39" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Desert." />
+      <property name="Text" value="As an additional cost for you to explore while at Sands of Dashur, you must spend 2 resources." />
+      <property name="Shroud" value="7" />
+      <property name="Clues" value="0" />
+    </card>
+    <card id="0c545af9-7363-4430-b350-73f636214099" name="Garden of Shadows" size="HorizCard">
+      <property name="Card Number" value="4" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Forced – If the strength of the abyss is 0 or 1: Set the strength of the abyss to 2. Each investigator either draws 1 card or heals 1 horror." />
+      <property name="Level" value="3" />
+      <property name="Doom" value="5" />
+      <alternate name="The Eternal Slumber" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="You are too exhausted to go on. Your mind screams at your body to keep moving, but your muscles have betrayed you. You sink to the ground like a sack of bricks.You resist with all of your strength, but all it amounts to is a wiggling of your fingers. You feel as though a heavy weight is pressed upon your head, and a dark cloak is thrown over your eyes.If you fall asleep here, you are sure you’ll never wake again. And yet, somehow, deep within your mind, you’re too tired to care.You yawn.Add 1 strength to the abyss.Each investigator who has not resigned is defeated and is “taken by the abyss.”" />
+        <property name="Level" value="3" />
+      </alternate>
+    </card>
+    <card id="520ddac8-f418-447d-949c-65e033ef3f0a" name="Dunes of the Sahara" size="EncounterCard">
+      <property name="Card Number" value="40" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Desert." />
+      <property name="Text" value="Forced – After you enter Dunes of the Sahara: You must either take 1 damage or lose 1 action." />
+      <property name="Shroud" value="3" />
+      <property name="Clues" value="1π" />
+    </card>
+    <card id="7de5bf96-e674-480b-8944-631473054e2d" name="Untouched Vault" size="EncounterCard">
+      <property name="Card Number" value="41" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Ruins." />
+      <property name="Text" value="Each Monster enemy at Untouched Vault gets +2 fight and +1 damage value.η If a Monster enemy was defeated here this round: You stare into the creature’s dead eyes, and the abyss stares back at you. Remove 1 strength from the abyss. (Group limit once per game.)" />
+      <property name="Shroud" value="4" />
+      <property name="Clues" value="1π" />
+    </card>
+    <card id="f2cd435e-4d43-4128-be45-1a0a04dfa933" name="Faceless Sphinx" size="EncounterCard">
+      <property name="Card Number" value="42" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Desert. Ruins." />
+      <property name="Text" value="X is the strength of the abyss.η If you have at least 2 clues: You stare into the sphinx’s empty face, and the abyss stares back at you. Place 2 of your clues on Faceless Sphinx and remove 1 strength from the abyss. (Group limit once per game.)" />
+      <property name="Shroud" value="X" />
+      <property name="Clues" value="1π" />
+    </card>
+    <card id="f8882391-13f3-4e1e-9614-79bd1d12c4de" name="Desert Oasis" size="EncounterCard">
+      <property name="Card Number" value="43" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Desert." />
+      <property name="Text" value="η: Heal 1 damage and 1 horror. (Limit once per game.)η η If you have no horror on you: You stare into the reflection on the water, and the abyss stares back at you. Take 3 horror and remove 1 strength from the abyss. (Group limit once per game.)" />
+      <property name="Shroud" value="5" />
+      <property name="Clues" value="1π" />
+    </card>
+    <card id="6f4123d8-df0f-40a2-a5c2-e01c8b676444" name="Sandswept Ruins" size="EncounterCard">
+      <property name="Card Number" value="44" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Expedition. Desert. Ruins." />
+      <property name="Text" value="While you are investigating Sandswept Ruins, if you have 5 or more cards in your hand, it gets +3 shroud.η η If you have 8 or more cards in your hand: You stare into the swirling sands, and the abyss stares back at you. Discard 3 cards from your hand at random and remove 1 strength from the abyss. (Group limit once per game.)" />
+      <property name="Shroud" value="3" />
+      <property name="Clues" value="1π" />
+    </card>
+    <card id="6f83b462-b1b7-4a89-bf88-451107cfd372" name="Abyssal Revenant" size="EncounterCard">
+      <property name="Card Number" value="45" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Dreamlands." />
+      <property name="Text" value="Spawn – Farthest Desert or Otherworld location.Hunter.Forced – When Abyssal Revenant attacks during the enemy phase: Instead of its standard damage, it deals X damage for this attack, where X is the strength of the abyss.  If this attack defeats an investigator or Ally asset, that card is “taken by the abyss.”" />
+      <property name="Health" value="4" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="2" />
+      <property name="Damage" value="1" />
+    </card>
+    <card id="c493e428-7118-4511-9061-443fc721553f" name="Thing in the Sarcophagus" size="EncounterCard">
+      <property name="Card Number" value="46" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster." />
+      <property name="Text" value="Spawn – The location with the most clues.While its location has no clues, Thing in the Sarcophagus gains hunter.Forced – When you attack Thing in the Sarcophagus by any means except a Ranged, Firearm, or Spell card, if it is ready: It immediately attacks you." />
+      <property name="Health" value="5" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="2" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="ced0d25b-5bb6-4d95-8d5c-ee67dccbcaad" name="Eclipse" size="EncounterCard">
+      <property name="Card Number" value="47" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Power." />
+      <property name="Text" value="While you are at an Otherworld location, Eclipse gains peril.Revelation – Test ά (3). If you fail, you must either take 2 horror or choose an Ally asset at your location to be defeated and “taken by the abyss.”" />
+    </card>
+    <card id="06868b35-d2fd-4f77-8fac-8ea464edc3eb" name="Sandstorm" size="EncounterCard">
+      <property name="Card Number" value="48" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Hazard." />
+      <property name="Text" value="While you are at a Desert location, Sandstorm gains peril.Revelation – Test ί (3). If you fail, you must either take 2 damage or discard an asset you control." />
+    </card>
+    <card id="1d584d46-29fc-4236-bb66-3448657afbd5" name="Terror Under the Pyramids" size="EncounterCard">
+      <property name="Card Number" value="49" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Scheme." />
+      <property name="Text" value="Revelation – Test ά (3). For each point you fail by, choose and discard 1 card from your hand. For each card you cannot discard, take 1 horror." />
+    </card>
+    <card id="d7f62f90-8f21-46fe-8e6e-80dc5ee2f074" name="Curse of Endless Sleep" size="HorizCard">
+      <property name="Card Number" value="5" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Forced – After a Brotherhood enemy enters the victory display: Flip it over and resolve the text on its other side.Objective – Find as many Evidence cards as you can and add them to the victory display before the agenda advances. (If there are 6 Evidence cards in the victory display, advance.)" />
+      <property name="Level" value="1" />
+      <alternate name="Into the Desert" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="You corner one of the organization’s agents in a dark alleyway as he attempts to flee the city. “It is too late to stop the prophecy,” he says with a frightened expression. “Please, just let me go.” Seeing weakness in the man’s heart, you tell him that he can help you stop what the organization is plotting, if he tells you everything he knows. “The Brotherhood of the Beast believes they have found their vessel,” he explains, stuttering nervously. “Now they’re giving their Chosen untold power. There’s no way you can stop them!” He struggles and breaks free from your grasp, fleeing back toward the main street. If you follow that man, perhaps he will lead you to the brotherhood’s hideout…Create the exploration deck by shuffling together each of the set-aside Expedition locations. Search the encounter deck and discard pile for 1 copy each of the following treachery cards: Terror Under the Pyramids, Swarm of Locusts, Abyssal Reach, Eclipse, and Sandstorm. Shuffle those cards into the exploration deck, then shuffle the encounter discard pile into the encounter deck.Each investigator loses each of his or her clues. Remove all clues from each Cairo location." />
+        <property name="Level" value="1" />
+      </alternate>
+    </card>
+    <card id="47ba1874-fa8f-4ebf-a13a-6ba8443d06da" name="Swarm of Locusts" size="EncounterCard">
+      <property name="Card Number" value="50" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Power." />
+      <property name="Text" value="Revelation – Test ί (3). For each point you fail by, lose 1 resource. For each resource you cannot lose, take 1 damage." />
+    </card>
+    <card id="df1ce467-6df1-4f5a-ad8d-45da14b0e356" name="Slumber" size="EncounterCard">
+      <property name="Card Number" value="51" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse. Abyss." />
+      <property name="Text" value="Revelation – Put Slumber into play in your threat area if there is no copy of it in your threat area (if there is, discard Slumber and it gains surge instead).Forced – When your turn begins: Test ά (2). If you fail, lose 1 action.ι After strength is removed from the abyss: Discard Slumber." />
+    </card>
+    <card id="8f1bf2cb-5bf1-41f6-9cea-f4ad0a5faac5" name="Dark Sacrifice" size="EncounterCard">
+      <property name="Card Number" value="52" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse. Abyss." />
+      <property name="Text" value="Revelation – Put Dark Sacrifice into play in your threat area if there is no copy of it in your threat area (if there is, discard Dark Sacrifice and it gains surge instead).Forced – After strength is added to the abyss: Take 1 damage and 1 horror. If this effect defeats an investigator or Ally asset, that card is “taken by the abyss.”ι After strength is removed from the abyss: Discard Dark Sacrifice." />
+    </card>
+    <card id="bb043564-e25b-405d-a70d-3438a4ccfa85" name="The Black Wind" size="EncounterCard">
+      <property name="Card Number" value="53" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Power." />
+      <property name="Text" value="Peril.Revelation – You must either (choose one): —Add 1 strength to the abyss and add The Black Wind to the victory display.—Discard The Black Wind and draw the top card of the encounter deck to replace it You get –1 to all skills for the remainder of this round.Victory 1." />
+      <property name="Victory Points" value="1" />
+    </card>
+    <card id="f7aa7f85-2d45-4e5c-bf57-065e688acdb1" name="Abyssal Reach" size="EncounterCard">
+      <property name="Card Number" value="54" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Sands of Egypt" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse. Abyss." />
+      <property name="Text" value="Revelation – Test ά (X). X is the strength of the abyss. If you fail by:—exactly 1, place 1 of your clues on your location. —exactly 2, take 1 damage and 1 horror.—exactly 3, you cannot play cards this round.—4 or more, place 1 doom on the current agenda (this effect may cause the current agenda to advance)." />
+    </card>
+    <card id="6deae397-9ef0-4b65-94f8-7f18ae67bb2b" name="John &amp; Jessie Burke">
+      <property name="Card Number" value="55" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Abyssal Tribute" />
+      <property name="Subtitle" value="Relentless in Pursuit" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Government." />
+      <property name="Text" value="η Exhaust John &amp; Jessie Burke and deal them 1 damage: Choose an enemy in a connecting location. Move to that enemy’s location. Then, engage that enemy and deal it 1 damage." />
+      <property name="Health" value="4" />
+      <property name="Sanity" value="2" />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="4" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="ήίΰ" />
+    </card>
+    <card id="57c884d2-9b48-4eaa-b226-9332f5eb1519" name="Ancient Ankh">
+      <property name="Card Number" value="56" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Abyssal Tribute" />
+      <property name="Subtitle" value="Aegis of the Harbinger" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Relic." />
+      <property name="Text" value="Uses (4 charges).ι When an investigator at your location would fail a test by more than 1, spend 1 charge: That investigator fails by 1, instead (even if he or she automatically failed)." />
+      <property name="Health" value="–" />
+      <property name="Sanity" value="3" />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Accessory" />
+      <property name="Skill Icons" value="άέΰ" />
+    </card>
+    <card id="90558a35-b226-4cd9-bd3e-303a6af0053b" name="Khopesh of the Abyss">
+      <property name="Card Number" value="57" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Abyssal Gifts" />
+      <property name="Subtitle" value="Manifested Malice" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Weapon. Relic. Melee." />
+      <property name="Text" value="η: Fight. You get +3 ή and deal +1 damage for this attack. ι After you defeat an enemy using Khopesh of the Abyss, exhaust it: Choose an enemy at another revealed location. Disengage from each other enemy engaged with you and move to the chosen enemy’s location. Then, engage that enemy." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="4" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="2 Hand" />
+      <property name="Unique" value="ο" />
+      <property name="Skill Icons" value="άήΰ" />
+    </card>
+    <card id="4e61c5c5-b665-472e-a324-ee76c1e6a727" name="Summoned Nightgaunt">
+      <property name="Card Number" value="58" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Abyssal Gifts" />
+      <property name="Subtitle" value="Gift from Nodens" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Monster. Nightgaunt. Power." />
+      <property name="Text" value="Uses (3 whistles). If Summoned Nightgaunt has no whistles, or if it leaves play, remove it from the game.η Spend 1 whistle and take 1 horror: Evade. Automatically evade all non-Nightgaunt enemies engaged with you and move to any revealed location." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="4" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="έίΰ" />
+    </card>
+    <card id="37bca18b-3e9a-4269-9909-bb14ac77525b" name="Secrets in the Sand" size="HorizCard">
+      <property name="Card Number" value="6" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Clues cannot be placed on Cairo locations.η If you are at an Expedition location: Explore. Draw the top card of the exploration deck. If it is a connecting location, put it into play and move to it." />
+      <property name="Level" value="2" />
+      <property name="Clues" value="3π" />
+      <alternate name="All for the Chosen" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="You are unable to find the Brotherhood’s hideout, but you are able to find the agent you interrogated in Cairo…Or at least, what remains of him. Inside the halls of an ancient temple, dedicated to a long-forgotten pharaoh, the man’s corpse has been placed upon a stone altar. His body is riddled with fresh stab wounds. You can’t help but wonder if this was—in a way—your doing. Investigating the body and the remainder of the half-buried temple yields a troubling discovery. As you suspected, the Brotherhood of the Beast is behind the curse afflicting Cairo. You find several passages describing the spell in greater detail—though these descriptions do not match what you have seen with your own eyes. The Brotherhood’s tomes describe how to transport their victims to another realm, a place called the Abyss. A nightmarescape from which the dreamers cannot awaken. With each dreamer, their “Chosen” grows in strength…Place 1[per investigator] damage tokens on each Cairo location. Until the end of the scenario, damage tokens on locations represent “dreamers”—victims who have been cursed with eternal slumber.Put the set-aside Neith enemy into play in the Streets of Cairo." />
+        <property name="Level" value="2" />
+      </alternate>
+    </card>
+    <card id="b8eec1aa-6855-4304-aa84-335c400fcb24" name="The Hour of Judgment" size="HorizCard">
+      <property name="Card Number" value="7" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="η If there is a dreamer at your location: Test ά or έ (X) to attempt to awaken a dreamer. X is the strength of the abyss. If you succeed, move a dreamer from your location to Neith, as damage.Objective – If Neith has no remaining health, advance." />
+      <property name="Level" value="3" />
+      <alternate name="The Harbinger's End" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="With each of the dreamers you set free, the arcane power wielded by Neith fades. Before long, she has collapsed to her knees, the power completely drained from her body. However, even with the spells and records you found in the Brotherhood’s temple, you’re unable to awaken all of the victims; only those most recently put under the spell’s sway. As for the remainder of the victims—including John Burke—their fate is inextricably tied to Neith. “If you believe that this is the end, you deserve the fate Xzharah has in store for you,” she warns you. “Slay me and you will be next in line to die.” You waver. But if she is allowed to live, those she has ensnared in sleep will never awaken. What is one life, compared to the lives of so many innocents?The investigators must decide (choose wisely):—Destroy Neith once and for all. By choosing this option, you believe those still under the curse of eternal slumber will be freed. (-&gt;R1)—Spare Neith and listen to what she has to say. By choosing this option, you believe you can learn more about the one Neith refers to as Xzharah. (-&gt;R2)" />
+        <property name="Level" value="3" />
+      </alternate>
+    </card>
+    <card id="b5def4cb-4ffb-4f1c-a392-bc04f93547ef" name="Streets of Cairo" size="EncounterCard">
+      <property name="Card Number" value="8" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Cairo." />
+      <alternate name="Streets of Cairo" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Cairo." />
+        <property name="Text" value="Forced – After you discover 2 or more clues at Streets of Cairo during a single turn: Take 1 horror.η If there are no clues on Streets of Cairo: Test ί (4). If you succeed, remember that you have “found a door marked with blood.”" />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="2π" />
+      </alternate>
+    </card>
+    <card id="2bf4d54f-e282-4ef1-b053-e3ede9fed974" name="Cairo Bazaar" size="EncounterCard">
+      <property name="Card Number" value="9" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Eternal Slumber" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Cairo." />
+      <alternate name="Cairo Bazaar" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Eternal Slumber" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Cairo." />
+        <property name="Text" value="While you are at Cairo Bazaar, reduce the cost of each Item asset you play by 1 and increase the cost of each other asset you play by 1.η Spend 10 resources: Remember that you “bought an odd trinket.”" />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+  </cards>
+</set>

--- a/o8g/Sets/In the Clutches of Chaos/set.xml
+++ b/o8g/Sets/In the Clutches of Chaos/set.xml
@@ -1,0 +1,588 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<set gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" id="ca03fc9b-9415-4c6a-9155-e0b17f9253c3" name="In the Clutches of Chaos" standalone="True" version="1.0.0" xmlns:noNamespaceSchemaLocation="CardSet.xsd">
+  <cards>
+    <card id="a15c7f7d-9134-4c3a-bf65-c75f6530f20a" name="Mk 1 Grenades">
+      <property name="Card Number" value="273" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Weapon. Ranged." />
+      <property name="Text" value="Uses (3 supplies). If Mk 1 Grenades has no supplies, discard it.η Spend 1 supply: Fight. You get +2 [ή] for this attack. If this attack is successful, instead of its standard damage, this attack deals 2 damage to each enemy and investigator at your location, other than yourself (any additional damage is dealt to the attacked enemy)." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="4" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ή" />
+    </card>
+    <card id="0b821253-834a-4409-9369-f8064a5fc030" name="Agency Backup">
+      <property name="Card Number" value="274" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Agency." />
+      <property name="Text" value="Agency Backup may be assigned damage and/or horror dealt to other investigators at your location.θ Exhaust Agency Backup and deal 1 damage to it: Deal 1 damage to an enemy at your location.θ Exhaust Agency Backup and deal 1 horror to it: Discover 1 clue at your location." />
+      <property name="Health" value="4" />
+      <property name="Sanity" value="4" />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="5" />
+      <property name="Cost" value="7" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="άέή" />
+    </card>
+    <card id="ff3ca836-7e98-4377-a358-d0d34bbf9b7a" name="Ghastly Revelation">
+      <property name="Card Number" value="275" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Spirit." />
+      <property name="Text" value="Discover 3 clues at your location. Give any number of your clues to another investigator, or place any number of your clues on any location. You are defeated and suffer 1 mental trauma. This action does not provoke attacks of opportunity." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="2" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="έέ" />
+    </card>
+    <card id="181db218-da56-4d41-87e5-563fb65fb2b4" name="Studious">
+      <property name="Card Number" value="276" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Talent." />
+      <property name="Text" value="Permanent.You begin each game with 1 additional card in your opening hand." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="–" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="" />
+    </card>
+    <card id="82615ef6-61e4-4517-903d-d1ba8dc924de" name="Small Favor">
+      <property name="Card Number" value="277" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Favor. Service." />
+      <property name="Text" value="Deal 1 damage to a non-Elite enemy at your location.ι When you play Small Favor, increase its cost by 2: Change “Deal 1 damage” to “Deal 2 damage.”ι When you play Small Favor, increase its cost by 2: Change “at your location” to “at a location up to 2 connections away.”" />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ήή" />
+    </card>
+    <card id="db60a14b-cd07-45ce-adf5-a3c2e10e689b" name="Another Day, Another Dollar">
+      <property name="Card Number" value="278" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Talent." />
+      <property name="Text" value="Permanent.You begin each game with 2 additional resources." />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="–" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="" />
+    </card>
+    <card id="a26c588a-1d36-4103-8fdc-1701649b7c83" name="Dayana Esperence">
+      <property name="Card Number" value="279" />
+      <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Deals with &quot;Devils&quot;" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Witch." />
+      <property name="Text" value="Uses (3 secrets).θ: Attach a non-weakness Spell event from your hand to Dayana Esperence. Limit 1 event attached to her.The attached event may be played as if it were in your hand. It is not placed in your discard pile after it is played (it remains attached). As an additional cost to play the attached event, exhaust Dayana Esperence and spend 1 secret." />
+      <property name="Health" value="3" />
+      <property name="Sanity" value="1" />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="4" />
+      <property name="Willpower" value="2" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="άά" />
+    </card>
+    <card id="68025ea2-341e-450f-94e5-18d9399a13c2" name="Deny Existence">
+      <property name="Card Number" value="280" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Spell. Paradox." />
+      <property name="Text" value="Fast. Play when an encounter card or enemy attack would cause you to do one of the following (choose one): Discard cards from hand, lose resources, lose actions, take damage, or take horror.You ignore that aspect of the effect. Then, perform the opposite of that aspect (draw cards, gain resources, gain additional actions, heal damage, or heal horror, respectively)." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="5" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ΰ" />
+    </card>
+    <card id="ff89e0fb-3f0a-4c71-9f8f-2fc3cf3fdb5c" name="Trial by Fire">
+      <property name="Card Number" value="281" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Spirit." />
+      <property name="Text" value="Fast. Play only during your turn.Choose one of your skills. Until the end of your turn, set the base value of that skill to 5." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ΰ" />
+    </card>
+    <card id="c26d9995-fc22-4400-926f-dc49e3210432" name="Bait and Switch">
+      <property name="Card Number" value="282" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Tactic." />
+      <property name="Text" value="Either (choose one):—Evade. If you succeed and the enemy is non-Elite, evade the enemy and move it to a connecting location.—Evade. Use only on a non-Elite enemy at a connecting location. If you succeed, evade that enemy and switch locations with it." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="2" />
+      <property name="Skill Icons" value="έίί" />
+    </card>
+    <card id="6d30fb09-a286-44e7-b504-267493c4704a" name="Anna Kaslow">
+      <property name="Card Number" value="283" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Clairvoyant." />
+      <property name="Text" value="You have 2 additional tarot slots.ι When the game begins, if Anna Kaslow is in your opening hand: Put her into play.ι After Anna Kaslow enters play: Search your deck for a Tarot asset and put it into play." />
+      <property name="Health" value="1" />
+      <property name="Sanity" value="1" />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="4" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="ΰ" />
+    </card>
+    <card id="af187725-013f-47b5-8f23-36439c776663" name="In the Clutches of Chaos" size="EncounterCard">
+      <property name="Card Number" value="284" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –X. X is the total amount of doom and breaches on your location.β: Reveal another token. If there are fewer than 3 breaches on your location, place 1 breach on your location.γ: –2. For each point you fail by, remove 1 breach from the current act.δ: –3. If you fail, place 1 breach on a random location." />
+      <alternate name="In the Clutches of Chaos" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –X. X is 1 higher than the total amount of doom and breaches on your location.β: Reveal another token. If there are fewer than 3 breaches on your location, place 1 breach on your location.γ: –3. For each point you fail by, remove 1 breach from the current act.δ: –4. If you fail, place 1 breach on a random location." />
+      </alternate>
+    </card>
+    <card id="e786c226-d4d7-48ff-a80a-4775a939dd91" name="THE CHARIOT · VII" size="HorizCard">
+      <property name="Card Number" value="285" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Forced – When doom would be placed on this agenda: Instead, place 1 breach on a number of different random locations equal to 1 more than the number of investigators.Forced – When a breach would be placed on a location with 3 breaches: Instead, resolve an incursion at that location." />
+      <alternate name="The Final Incantation" size="HorizCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="The stars vanish in the night sky as the maw of the void swallows the horizon. The muffled beating of maddening drums and the thin whine of otherworldly flutes drift through the emptiness.Check Campaign Log.—If Anette Mason has been possessed, (→R3).—If Carl Sanford possesses the secrets of the universe, (→R4)." />
+      </alternate>
+    </card>
+    <card id="d8c145e0-aef1-4e62-a68d-4d2cc1dd16f9" name="Dark Knowledge (v. I)" size="HorizCard">
+      <property name="Card Number" value="286" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Music of the Damned" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ Remove 3 breaches from this act: Place 1 clue on a random location.Objective – When the investigators have collected the requisite number of clues, they must immediately spend them and advance. When this act advances, move all of the breaches on it to the next act." />
+      <alternate name="Anette Mason" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Music of the Damned" />
+        <property name="Subtitle" value="Reincarnated Evil" />
+        <property name="Type" value="Enemy" />
+        <property name="Traits" value="Humanoid. Witch. Servitor. Elite." />
+        <property name="Text" value="Spawn – Hangman’s Hill.Alert. Hunter.Anette Mason gets –2 health for each clue controlled by an investigator.Forced – After 1 or more breaches are placed on Anette Mason’s location: Each investigator must either take 1 damage or 1 horror." />
+        <property name="Health" value="6π" />
+        <property name="Combat" value="5" />
+        <property name="Agility" value="3" />
+        <property name="Unique" value="*" />
+        <property name="Damage" value="3" />
+        <property name="Horror" value="1" />
+        <property name="Victory Points" value="2" />
+      </alternate>
+    </card>
+    <card id="8f329d22-5e4c-4be6-9779-4f24f80159c7" name="Beyond the Grave" size="HorizCard">
+      <property name="Card Number" value="287" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Music of the Damned" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ Remove 3 breaches from this act: Place 1 clue on a random location.Objective – If Anette Mason is defeated, advance." />
+      <alternate name="The Living and the Dead" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Music of the Damned" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Somehow, despite all odds, you have managed to defeat the resurrected spirit which torments Anette Mason. She passes out and collapses to the ground, but the revenant inside forces her eyes open and puppeteers her body in a lurid display. “Fools!” the ragged, disembodied voice of Keziah declares through Anette’s lips as she rises once more. “You are naught but insects. I have seen the truth. I have seen the face of Chaos itself, and you will soon be a part of it. Now, come; join me, kneel before the Black Throne, and be one with the universe!”You shudder as the words reach your ears. Nothing she says makes sense to you, but you can tell her intent is dark and wicked. “Leave this place,” you muster up the will to command, “Go back to the beyond from which you were summoned, and never return.”(→R1)" />
+      </alternate>
+    </card>
+    <card id="d200f45b-a3d2-4590-8117-6608ecb996eb" name="Dark Knowledge (v. II)" size="HorizCard">
+      <property name="Card Number" value="288" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Secrets of the Universe" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ Remove 3 breaches from this act: Place 1 clue on a random location.Objective – When the investigators have collected the requisite number of clues, they must immediately spend them and advance. When this act advances, move all of the breaches on it to the next act." />
+      <alternate name="Carl Sanford" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Secrets of the Universe" />
+        <property name="Subtitle" value="Deathless Fanatic" />
+        <property name="Type" value="Enemy" />
+        <property name="Traits" value="Humanoid. Silver Twilight. Elite." />
+        <property name="Text" value="Spawn – Silver Twilight Lodge.Hunter. Retaliate.Carl Sanford gets –2 health for each clue controlled by an investigator.Forced – After any number of breaches are removed from the current act: Place 1 of them on Carl Sanford’s location." />
+        <property name="Health" value="6π" />
+        <property name="Combat" value="4" />
+        <property name="Agility" value="4" />
+        <property name="Unique" value="*" />
+        <property name="Damage" value="1" />
+        <property name="Horror" value="3" />
+        <property name="Victory Points" value="2" />
+      </alternate>
+    </card>
+    <card id="106a08d0-4732-4568-a864-c7c30752fe02" name="New World Order" size="HorizCard">
+      <property name="Card Number" value="289" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Secrets of the Universe" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ Remove 3 breaches from this act: Place 1 clue on a random location.Objective – If Carl Sanford is defeated, advance." />
+      <alternate name="Of Gods and Mortals" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Secrets of the Universe" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Using force and ingenuity, you have managed to defeat Carl Sanford at his own game. The power he was drawing from surges painfully through him. “You imbeciles,” he spits, “what do you think you have accomplished? We could have been immortal. Don’t you understand? We could have been gods!” he struggles to remain on his feet, his strength waning as he loses control of his power.“At what cost?” You reply, taking in the sight before you. “You would have made us slaves, not gods. Slaves to your greed and the Order’s power. I’d rather stay mortal than be your thrall.”“Then we will all perish,” Carl responds bitterly. “I could have made us into celestials. Instead, we will be extinct. I hope you are satisfied.”(→R2)" />
+      </alternate>
+    </card>
+    <card id="5b1b97df-7bc1-42e8-aa55-c45ab8e4129d" name="French Hill" size="EncounterCard">
+      <property name="Card Number" value="290" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="French Hill" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η Choose and discard a card from your hand: Move 1 breach from French Hill to the current act, +1 additional breach for each [ά] icon on that card." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="96e24b77-d561-4726-a36a-fdc0c8d14cea" name="French Hill" size="EncounterCard">
+      <property name="Card Number" value="291" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="French Hill" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η: Test [ά] (2). For each point you succeed by, move 1 breach from French Hill to the current act." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="a98aea8f-073e-41e0-a739-78599ece71b2" name="Rivertown" size="EncounterCard">
+      <property name="Card Number" value="292" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Rivertown" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η Choose and discard a card from your hand: Move 1 breach from Rivertown to the current act, +1 additional breach for each [έ] icon on that card." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="4c511cf5-07d3-4c4a-94ac-f3b392d863b8" name="Rivertown" size="EncounterCard">
+      <property name="Card Number" value="293" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Rivertown" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η: Test [έ] (2). For each point you succeed by, move 1 breach from Rivertown to the current act." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="939cecea-c846-4ffd-bb1b-39e848b75710" name="Southside" size="EncounterCard">
+      <property name="Card Number" value="294" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham. Central." />
+      <alternate name="Southside" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham. Central." />
+        <property name="Text" value="θ: Discard the top 3 cards of the encounter deck and move 1 breach from Southside to the current act. Choose a Power treachery discarded by this effect and resolve its revelation ability, if able." />
+        <property name="Shroud" value="1" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="af069455-dd28-47ba-9e14-0c559695332b" name="Southside" size="EncounterCard">
+      <property name="Card Number" value="295" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham. Central." />
+      <alternate name="Southside" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham. Central." />
+        <property name="Text" value="θ Choose and discard any number of cards from your hand: For each card discarded in this way, move 1 breach from Southside to the current act." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="e8f91327-fe0a-4a84-b953-2e78bef56ac0" name="Uptown" size="EncounterCard">
+      <property name="Card Number" value="296" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Uptown" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η Choose and discard a card from your hand: Move 1 breach from Uptown to the current act, +1 additional breach for each [ί] icon on that card." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="73b8bb44-802b-47ec-9bb8-ec31836671e7" name="Uptown" size="EncounterCard">
+      <property name="Card Number" value="297" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Uptown" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η: Test [ί] (2). For each point you succeed by, move 1 breach from Uptown to the current act." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="c2bb0fb9-fa46-4f7b-b33d-c0c0776050b8" name="South Church" size="EncounterCard">
+      <property name="Card Number" value="298" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="South Church" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η: Draw the top card of the encounter deck. Then, move all breaches from South Church to the current act.η: Resign. You hide through the night." />
+        <property name="Shroud" value="1" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="94a14d03-9193-4f51-99dc-b08f8817d33c" name="South Church" size="EncounterCard">
+      <property name="Card Number" value="299" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="South Church" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η Discard an asset you control from play: Move all breaches from South Church to the current act.η: Resign. You hide through the night." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="140e4849-4849-4cb8-9888-0d7647da8a50" name="Merchant District" size="EncounterCard">
+      <property name="Card Number" value="300" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Merchant District" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η Discard the top 5, 10, or 15 cards of your deck: For every 5 cards discarded in this way, move 1 breach from Merchant District to the current act. Draw each weakness discarded in this way." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="8fc7e31e-9a02-4896-8c98-7f7202bbd4ee" name="Merchant District" size="EncounterCard">
+      <property name="Card Number" value="301" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Merchant District" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="θ Spend 2 resources: Move 1 breach from Merchant District to the current act." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="57b76424-5b5f-4a7d-b256-4e057055bdf5" name="Hangman’s Hill" size="EncounterCard">
+      <property name="Card Number" value="302" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Music of the Damned" />
+      <property name="Subtitle" value="Where It All Ends" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Hangman’s Hill" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Music of the Damned" />
+        <property name="Subtitle" value="Where It All Ends" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η: Search the encounter deck and discard pile for a Witch enemy and draw it. Then, move all breaches from Hangman’s Hill to the current act. Shuffle the encounter deck." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="2cc3aacd-9eb4-4c88-92a8-f421a5477ef3" name="Silver Twilight Lodge" size="EncounterCard">
+      <property name="Card Number" value="303" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Music of the Damned" />
+      <property name="Subtitle" value="Shrouded In Mystery" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Silver Twilight Lodge" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Music of the Damned" />
+        <property name="Subtitle" value="Shrouded In Mystery" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="θ Take 1 horror: Move 1 breach from Silver Twilight Lodge to the current act." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="b03f1a0d-3025-410c-861f-8524f860fc3c" name="Hangman’s Hill" size="EncounterCard">
+      <property name="Card Number" value="304" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Secrets of the Universe" />
+      <property name="Subtitle" value="Shrouded In Mystery" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Hangman’s Hill" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Secrets of the Universe" />
+        <property name="Subtitle" value="Shrouded In Mystery" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="θ Take 1 damage: Move 1 breach from Hangman’s Hill to the current act." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="954fe8ed-0104-4621-903f-f56ac91c961a" name="Silver Twilight Lodge" size="EncounterCard">
+      <property name="Card Number" value="305" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Secrets of the Universe" />
+      <property name="Subtitle" value="Where It All Ends" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Arkham." />
+      <alternate name="Silver Twilight Lodge" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Secrets of the Universe" />
+        <property name="Subtitle" value="Where It All Ends" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Arkham." />
+        <property name="Text" value="η: Search the encounter deck and discard pile for a Silver Twilight enemy and draw it. Then, move all breaches from Silver Twilight Lodge to the current act. Shuffle the encounter deck." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="e69a16e5-2d20-4f88-8691-9cf21ac05fb7" name="Chaos Manifest" size="EncounterCard">
+      <property name="Card Number" value="306" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Power." />
+      <property name="Text" value="Revelation – Test [ά] (3). Place 1 breach on X different random locations, where X is the amount you failed by." />
+    </card>
+    <card id="2e096aff-2f1f-4590-92f3-0a0766d4fde0" name="Primordial Gateway" size="EncounterCard">
+      <property name="Card Number" value="307" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Power." />
+      <property name="Text" value="Revelation – Attach to a random location. Place breaches on attached location until there are exactly 3 breaches on it.Treat the attached location as if its printed text box were blank (except for Traits).η: Test [έ] or [ά] (4) to close the gateway. If you succeed, discard Primordial Gateway." />
+    </card>
+    <card id="bb227dd9-c7cc-4b63-8479-1c16de046539" name="Terror Unleashed" size="EncounterCard">
+      <property name="Card Number" value="308" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse." />
+      <property name="Text" value="Revelation – If there are no breaches on your location, place 1 breach on your location. You must take X damage or horror, divided as you wish. X is the total amount of doom and breaches on your location." />
+    </card>
+    <card id="2809f893-3aa8-468a-943a-372bef4f909b" name="Lodge Enforcer" size="EncounterCard">
+      <property name="Card Number" value="309" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Secrets of the Universe" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Cultist. Silver Twilight." />
+      <property name="Text" value="Spawn – Most breaches (or Silver Twilight Lodge if there are no locations in play with breaches on them).Retaliate.Treat Lodge Enforcer’s location as if its printed text box were blank (except for Traits)." />
+      <property name="Health" value="4" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <property name="Victory Points" value="1" />
+    </card>
+    <card id="e822c46c-76de-4827-8fd5-b84400c8b212" name="Secrets of the Beyond" size="EncounterCard">
+      <property name="Card Number" value="310" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Secrets of the Universe" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Hex." />
+      <property name="Text" value="Revelation – Find the Cultist enemy in play with the most doom on it. For each doom on that enemy, place 1 breach on that enemy’s location. If no breaches are placed by this effect, Secrets of the Beyond gains surge." />
+    </card>
+    <card id="007690be-09a3-42ae-a691-a85543ffedb9" name="Witness of Chaos" size="EncounterCard">
+      <property name="Card Number" value="311" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Music of the Damned" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Witch." />
+      <property name="Text" value="Spawn – Fewest breaches.Hunter.Forced – After Witness of Chaos enters a location: Place 1 breach on that location." />
+      <property name="Health" value="4" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="2" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <property name="Victory Points" value="1" />
+    </card>
+    <card id="dbe9eddf-d8f7-4f76-855a-44393619cea1" name="Toil and Trouble" size="EncounterCard">
+      <property name="Card Number" value="312" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Music of the Damned" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Hex." />
+      <property name="Text" value="Peril.Revelation – You must either (choose one):—Resolve the revelation ability on the topmost Power treachery in the encounter discard pile.—Resolve an incursion at your location." />
+    </card>
+  </cards>
+</set>

--- a/o8g/Sets/The Secret Name/set.xml
+++ b/o8g/Sets/The Secret Name/set.xml
@@ -1,0 +1,611 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<set gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" id="6bbb487e-76cf-4f8f-a25d-fe2b1e0593a1" name="The Secret Name" standalone="True" version="1.0.0" xmlns:noNamespaceSchemaLocation="CardSet.xsd">
+  <cards>
+    <card id="e589f209-7f5a-4d21-929c-c1dea4cdbda3" name="Something Worth Fighting For">
+      <property name="Card Number" value="109" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Talent." />
+      <property name="Text" value="Something Worth Fighting For may be assigned horror dealt to other investigators at your location." />
+      <property name="Sanity" value="3" />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="aab0789f-f556-42ef-a9b9-22687740cf52" name="Crack the Case">
+      <property name="Card Number" value="110" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Insight." />
+      <property name="Text" value="Fast. Play after an investigator discovers the last remaining clue at your location.Investigators at that location gain a total of X resources, distributed as you wish. X is that location’s shroud value." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="έ" />
+    </card>
+    <card id="46d65f31-2a1f-440c-b466-c972b91880d9" name="Intel Report">
+      <property name="Card Number" value="111" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Favor. Service." />
+      <property name="Text" value="Discover 1 clue at your location.ι When you play Intel Report, increase its cost by 2: Change “Discover 1 clue” to “Discover 2 clues.”ι When you play Intel Report, increase its cost by 2: Change “at your location” to “at a location up to 2 connections away.”" />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="2" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="έέ" />
+    </card>
+    <card id="7375d1fa-197c-451b-9992-fd8350a77047" name="Sign Magick">
+      <property name="Card Number" value="112" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ritual. Talent." />
+      <property name="Text" value="Fast.You have 1 additional arcane slot, which can only be used to hold a Spell or Ritual asset." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="8a472fd7-bd16-456b-b390-37d52203e49a" name="Banish">
+      <property name="Card Number" value="113" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="Evade. Use only on a non-Elite enemy. This evasion attempt uses ά instead of ί. If you succeed, move the enemy just evaded to any location in play. If you succeed and a α, β, γ, or δ symbol was revealed during this evasion attempt, that enemy does not ready during the next upkeep phase." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="1" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="άί" />
+    </card>
+    <card id="c6b30d15-60f6-4a8e-a133-78ef64a97875" name="Meat Cleaver">
+      <property name="Card Number" value="114" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Weapon. Melee." />
+      <property name="Text" value="η: Fight. You get +1 ή for this attack (+2 ή instead if you have 3 or fewer remaining sanity). If this attack defeats an enemy, you may heal 1 horror. As an additional cost to initiate this ability, you may take 1 horror to have this attack deal +1 damage." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="ή" />
+    </card>
+    <card id="ceb0189a-107b-41ce-8892-2c6cf36bc161" name=".45 Thompson">
+      <property name="Card Number" value="115" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Weapon. Firearm. Illicit." />
+      <property name="Text" value="Uses (5 ammo).η Spend 1 ammo: Fight. You get +2 ή and deal +1 damage for this attack." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="6" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="2 Hand" />
+      <property name="Skill Icons" value="ή" />
+    </card>
+    <card id="a9990ab5-25b1-40aa-9436-e24bd889bfd7" name="Scroll of Secrets">
+      <property name="Card Number" value="116" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tome." />
+      <property name="Text" value="Uses (3 secrets).η Exhaust Scroll of Secrets and spend 1 secret: Look at the bottom card of any investigator's deck or the encounter deck. Then, either discard that card, add it to its owner’s hand, place it on the bottom of its deck, or place it on the top of its deck." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="έ" />
+    </card>
+    <card id="a6a7aee0-dff7-4ed1-8bc0-1283c7862276" name="Tennessee Sour Mash">
+      <property name="Card Number" value="117" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Illicit." />
+      <property name="Text" value="Uses (2 supplies).θ Exhaust Tennessee Sour Mash and spend 1 supply: You get +2 ά for a skill test on a treachery card.η Discard Tennessee Sour Mash: Fight. You get +3 ή for this attack." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="4b84085b-8c31-4249-bb8e-ceda3be4f10f" name="Enchanted Blade">
+      <property name="Card Number" value="118" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Relic. Weapon. Melee." />
+      <property name="Text" value="Uses (3 charges).η: Fight. You get +1 ή for this attack. As an additional cost to initiate this ability, you may spend 1 charge to empower the blade. If you do, you get +1 ή and deal +1 damage for this attack." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Hand Arcane" />
+      <property name="Skill Icons" value="ή" />
+    </card>
+    <card id="0d126534-3b25-4157-93b0-c0ff4357d3a2" name="Grisly Totem">
+      <property name="Card Number" value="119" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Charm." />
+      <property name="Text" value="ι After you commit a card to a skill test, exhaust Grisly Totem: That card gains another instance of one of its skill icons of your choice." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="Accessory" />
+      <property name="Skill Icons" value="ί" />
+    </card>
+    <card id="33bfb887-f781-43f9-a8a5-4677f811ca24" name="The Secret Name" size="EncounterCard">
+      <property name="Card Number" value="120" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="EASY / STANDARD" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –1 (–3 instead if you are at an Extradimensional location).β: Reveal another chaos token. If you fail, discard the top 3 cards of the encounter deck.γ: –2. If you fail and Nahab is at your location, she attacks you.δ: –3. If you fail, resolve the hunter keyword on each enemy in play." />
+      <alternate name="The Secret Name" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="HARD / EXPERT" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –2 (–4 instead if you are at an Extradimensional location).β: Reveal another chaos token. If you fail, discard the top 5 cards of the encounter deck.γ: –3. If you fail and Nahab is in play, she attacks you (regardless of her current location).δ: –4. Resolve the hunter keyword on each enemy in play." />
+      </alternate>
+    </card>
+    <card id="68d761f4-60ae-46cd-9f7a-824b13ee5a55" name="THE HERMIT · IX" size="HorizCard">
+      <property name="Card Number" value="121" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Agenda 1a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each non-weakness enemy gets +1 health.ι After you defeat Brown Jenkin or Nahab: Gain 1 clue from the token bank (2 clues instead if there are 3 or more investigators in the game)." />
+      <property name="Doom" value="4" />
+      <alternate name="Rats in the Walls" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Agenda 1b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="As you explore the old, dilapidated house, the telltale scratching and scurrying in the walls becomes louder and more frequent. Every now and again a fanged, furry creature darts across the wooden floor, scampering in and out of ratholes in the walls. You wonder if this house is more rat than wood.If Brown Jenkin is in play, search the encounter deck and discard pile for a Swarm of Rats and spawn it in Brown Jenkin’s location. If Brown Jenkin is not in play, search the encounter deck and discard pile for him and spawn it in the lead investigator’s location.Additionally, if there are 3 or 4 investigators in the game, search the encounter deck and discard pile for a Swarm of Rats and spawn it in any Witch House location." />
+      </alternate>
+    </card>
+    <card id="4e77739e-b214-4a6b-b847-2a0817d7793f" name="The Familiar" size="HorizCard">
+      <property name="Card Number" value="122" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Agenda 2a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each non-weakness enemy gets +2 health.ι After you defeat Brown Jenkin or Nahab: Gain 1 clue from the token bank (2 clues instead if there are 3 or more investigators in the game)." />
+      <property name="Doom" value="6" />
+      <alternate name="The Crone" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Agenda 2b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="A dizzying violet light emerges from the crevices of the ramshackle house, behind cracks in the wooden paneling and underneath the floor, bathing you from every angle. An inhuman squeal mocks you as a figure emerges from the witch light. Only a hint of humanity remains in her crooked and broken form. The crone cackles with a nightmarish timbre, her voice echoing and resounding from the realm beyond.—If it is act 1, spawn the set-aside Nahab in Walter Gilman’s Room.—If it is act 2, spawn the set-aside Nahab in Keziah’s Room.—If it is act 3, place 1 doom on Nahab.Find Brown Jenkin (even if he is out of play) and place him in Nahab’s current location." />
+      </alternate>
+    </card>
+    <card id="b2ca1fb9-e670-45af-b273-deb03b848c4e" name="The Witch Light" size="HorizCard">
+      <property name="Card Number" value="123" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Agenda 3a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each non-weakness enemy gets +3 health.ι After you defeat Brown Jenkin or Nahab: Gain 1 clue from the token bank (2 clues instead if there are 3 or more investigators in the game)." />
+      <property name="Doom" value="8" />
+      <alternate name="An Awakening" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Agenda 3b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="A sudden flash of violet light causes you to reel backwards. The spectral form of the crone is broken and shattered, but as you fall you can see a sinister grin play across her misshapen face. A jolt of pain surges through you as your head strikes the surface of the wall, and the witch’s terrible grin is the last thing you see before everything goes black.When you awaken, the witch light is gone, but a vision is burned in your mind—the ancient crone, bent over a slanted floor, leering gleefully at a rotting book, a misshapen knife in her crooked fingers. Behind her, the twilight abyss extends into oblivion, and a gaping maw begins to close.—If it is act 1 or 2, set Nahab aside, out of play, and place 4 doom on agenda 4a as it enters play.—If it is act 3, place 1 doom on Nahab." />
+      </alternate>
+    </card>
+    <card id="53615356-f0c1-4cc2-9ba2-e1fffa146284" name="Marked for Sacrifice" size="HorizCard">
+      <property name="Card Number" value="124" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Agenda 4a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Each non-weakness enemy gets +4 health.ι After you defeat Brown Jenkin or Nahab: Gain 1 clue (from the token bank) (2 clues instead if there are 3 or more investigators in the game)." />
+      <property name="Doom" value="8" />
+      <alternate name="A Dream in the Witch House" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Agenda 4b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="Flashes of vision spark your memory as you are dragged along the dirty wooden floor. A foul ceremony—the house—Nahab—a rhythmic chant—the spiraling black vortex—a dark revelry—the Primal Chaos—a child’s cries—a writhing tunnel inside your chest.(→ R1)" />
+      </alternate>
+    </card>
+    <card id="8449d441-eb20-4b6c-94c5-3b9f3700d709" name="Investigating the Witch House" size="HorizCard">
+      <property name="Card Number" value="125" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Act 1a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Objective – If each undefeated investigator is in Walter Gilman’s Room, investigators may spend the requisite number of clues, as a group, to advance." />
+      <property name="Clues" value="3π" />
+      <alternate name="Specter of the Past" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Act 1b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Standing in a dead man’s room is disconcerting enough, but what you find within is enough to make you want to leave and never return. Walter Gilman’s journal is filled with descriptions of his dreams and visions, each more terrifying and perplexing than the last. He mentions seeing the figure of Keziah Mason on more than one occasion, and at one point calls her by another name: “Nahab.” As soon as you read the name aloud, the nearby window shatters, and an all-too-familiar spectral mist invades the cramped space. When it recedes, everything about the room has changed. A work desk and an aged bookshelf occupy the far corner of Gilman’s room, where his bed should be. The door you entered from is gone. Strange geometrical markings, drawn with a sticky red substance, cover the walls.Swap Walter Gilman’s Room with the set-aside Keziah’s Room, taking its place (all tokens and cards at the former location are now at the new location). Remove each other location in play from the game. Choose an investigator to take control of the set-aside The Black Book asset. Shuffle both set-aside copies of Strange Geometry into the encounter deck." />
+      </alternate>
+    </card>
+    <card id="af8fda52-08c1-4706-98a2-85e9eb31bf4f" name="Beyond the Witch House" size="HorizCard">
+      <property name="Card Number" value="126" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Act 2a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Objective – Only investigators in the Witch House Ruins may spend the requisite number of clues, as a group, to advance." />
+      <property name="Clues" value="5π" />
+      <alternate name="A Profane Ritual" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Act 2b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Searching through the ruins, you find a rotting hole in the slanted ceiling, leading to a closed-off attic. Amidst the debris are crushed and splintered bones, some human and some…not. More of Keziah’s awful tomes are scattered about, filled with pages of dark rituals and black spellcraft. On the floor, a circle has been carved—or perhaps gnawed—into the wood. At the center lies a spatter of dried blood and a jagged knife. What terrible rituals were performed in this profane space? Perhaps there is a way you can know for sure. You take the knife and prick your hand deep enough for blood to well in your palm. Using Keziah’s formulae, you draw a pattern in the circle, and carve a path through time…Put the set-aside Site of the Sacrifice location into play.—If it is agenda 1, 2, or 3, find Nahab (even if she is out of play), place 2 doom on her, and place her at the Site of the Sacrifice.—If it is agenda 4, find Nahab (even if she is out of play) and place her at the Site of the Sacrifice. Move each doom from agenda 4a to Nahab.Find Brown Jenkin (even if he is out of play) and place him in Nahab’s current location." />
+      </alternate>
+    </card>
+    <card id="c6c424f9-f540-4369-9869-1946a55c30dd" name="Stopping the Ritual" size="HorizCard">
+      <property name="Card Number" value="127" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Act 3a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Nahab cannot leave the Site of the Sacrifice.Forced – When Nahab is defeated: Instead of discarding her, heal all damage from her, disengage her from all investigators, and exhaust her. She does not ready during the upkeep phase this round.Objective – If there is no doom on Nahab, advance." />
+      <alternate name="Ritual Averted" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Act 3b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="The ancient crone lets out a banshee’s wail as you dismantle her unholy ritual. The room unfurls through space-time, the cramped, slanted walls unfolding to reveal the oblivion beyond. The creature who was once Keziah Mason croaks a loathsome curse as her shapeless form is pulled into the void. Bit by bit, the wood-paneled flooring below your feet breaks apart. Then you are ripped—the pull from the stars—a muddy alleyway—the flute in the woods—the roaring abyss—the gaze of the watcher—The Tower—a green hillside—the black vortex—the screams of the accused—the piper—three arrows—a sacrifice—a ringing bell—an ascension—and you emerge from the anomaly, crashing painfully onto the floor.(→ R2)" />
+      </alternate>
+    </card>
+    <card id="54164db4-ac3b-4b32-92a3-2847729fb7df" name="Moldy Halls" size="EncounterCard">
+      <property name="Card Number" value="128" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Witch House." />
+      <alternate name="Moldy Halls" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Witch House." />
+        <property name="Text" value="Haunted – Lose 3 resources." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="fcb27e66-5c77-4edf-b418-e0b205add86f" name="Decrepit Door" size="EncounterCard">
+      <property name="Card Number" value="129" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Witch House." />
+      <alternate name="Landlord's Quarters" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Witch House." />
+        <property name="Text" value="Forced – After you reveal Landlord’s Quarters: Search the encounter deck and discard pile for a Swarm of Rats and spawn it in Mouldy Halls. Shuffle the encounter deck.Haunted – Search the encounter deck and discard pile for a Swarm of Rats and spawn it in Mouldy Halls. Shuffle the encounter deck." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="af26112b-c8d8-48e3-9e36-f6aae87f568e" name="Decrepit Door" size="EncounterCard">
+      <property name="Card Number" value="130" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Witch House." />
+      <alternate name="Joe Mazurewicz's Room" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Witch House." />
+        <property name="Text" value="η: Search your deck for a Blessed or Item asset and add it to your hand. (Group limit once per game.)Haunted – You must either take 1 horror, or choose and discard an asset you control." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="240f4107-e6d9-4820-91d3-7365cc40407c" name="Decrepit Door" size="EncounterCard">
+      <property name="Card Number" value="131" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Witch House." />
+      <alternate name="Frank Elwood's Room" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Witch House." />
+        <property name="Text" value="Haunted – You must either place 1 of your clues on Frank Elwood’s Room, or place 1 doom on the current agenda." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="b89c14d2-c0bb-4e99-9c9d-1ba0aff7b2bd" name="Walter Gilman’s Room" size="EncounterCard">
+      <property name="Card Number" value="132" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Witch House." />
+      <property name="Text" value="The door to Walter Gilman’s room is locked. As an additional cost to enter Walter Gilman’s room, investigators in the Moldy Halls must spend 1[per investigator] clues, as a group." />
+      <alternate name="Walter Gilman’s Room" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Witch House." />
+        <property name="Text" value="η: Draw 3 cards and take 1 horror. (Limit once per game.)Haunted – Discard the top 2 cards of the encounter deck." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="e9721e11-b617-4b4b-a37d-18c1e3028f9e" name="Keziah’s Room" size="EncounterCard">
+      <property name="Card Number" value="133" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Spectral. Witch House." />
+      <alternate name="Keziah’s Room" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral. Witch House." />
+        <property name="Text" value="ι After you successfully investigate Keziah’s Room: Instead of discovering clues, put the top card of the Unknown Places deck into play, unrevealed. Then, you may move to that location.Haunted – Discard cards from the top of the encounter deck until a Hex card is discarded. Draw that card." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="944e0e93-e42a-4eef-9d4e-9df72ec47061" name="Unknown Places" size="EncounterCard">
+      <property name="Card Number" value="134" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <alternate name="Moldy Halls" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="Earlier Tonight" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Witch House." />
+        <property name="Text" value="η: You request aid from your past self. Each investigator at this location may return 1 card from his or her discard pile to his or her hand. Each investigator who does so remembers that he or she “meddled with the past.” (Group limit once per game.)" />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="859032e6-06fd-425d-884b-bca6585af5ae" name="Unknown Places" size="EncounterCard">
+      <property name="Card Number" value="135" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <alternate name="Twilight Abyss" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Otherworld." />
+        <property name="Text" value="Forced – After you enter Twilight Abyss, test ή or ί (3). For each point you fail by, take 1 damage." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="d96b9e82-4855-4dcc-9fed-e1bc6282a550" name="Unknown Places" size="EncounterCard">
+      <property name="Card Number" value="136" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <alternate name="City of Elder Things" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Otherworld." />
+        <property name="Text" value="ι After you reveal City of Elder Things, take 2 horror: Put the top card of the Unknown Places deck into play, unrevealed. For the remainder of the scenario, City of Elder Things is considered to be connected to that location, and vice versa." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="33254ae5-0821-43db-95ba-66c661c2307f" name="Unknown Places" size="EncounterCard">
+      <property name="Card Number" value="137" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <alternate name="Witch House Ruins" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Witch House." />
+        <property name="Text" value="η: Investigate. If you succeed, instead of discovering clues, heal 2 horror. (Limit once per game.)Haunted – Lose 1 action." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="2cd4a5aa-5ce5-4bc6-a9c3-99b526b566a9" name="Unknown Places" size="EncounterCard">
+      <property name="Card Number" value="138" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <alternate name="Salem Gaol, 1692" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Salem." />
+        <property name="Text" value="η: Test έ (3). If you succeed, move to any revealed location. (Limit once per game.)Haunted – Move to Keziah’s Room." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="f10e703a-742d-4814-a62c-c1125e48ece6" name="Unknown Places" size="EncounterCard">
+      <property name="Card Number" value="139" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <alternate name="Physics Classroom" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Miskatonic." />
+        <property name="Text" value="ι After you successfully investigate Physics Classroom by 2 or more: Discover a clue at another revealed location. (Limit once per round.)" />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="ef4104f5-64da-45f6-9e2a-bdf9be22949d" name="Unknown Places" size="EncounterCard">
+      <property name="Card Number" value="140" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <alternate name="Court of the Great Old Ones" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Subtitle" value="A Not-Too-Distant Future" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Otherworld." />
+        <property name="Text" value="Forced – After you enter Court of the Great Old Ones, test ά (3). For each point you fail by, take 1 horror.Haunted – The next action you perform this round must be an investigate action." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="8293e074-4c6b-4477-8630-eb47ef585150" name="Site of the Sacrifice" size="EncounterCard">
+      <property name="Card Number" value="141" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional. Witch House." />
+      <alternate name="Site of the Sacrifice" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Secret Name" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Extradimensional. Witch House." />
+        <property name="Text" value="η Investigators at this location spend 1[per investigator] clues, as a group: Remove 1 doom from Nahab. This action does not provoke attacks of opportunity from Nahab.Forced – At the end of the round: Add clues to this location until it has 3[per investigator] clues on it.Haunted – You must either place 1 doom on Nahab, or Nahab attacks you." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="3π" />
+      </alternate>
+    </card>
+    <card id="c63d6de9-9ae0-4cfb-a561-b0b2e58dffb7" name="Strange Geometry" size="EncounterCard">
+      <property name="Card Number" value="142" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Extradimensional." />
+      <property name="Text" value="Revelation – Put Strange Geometry into play and move to it. Forced  – After the investigation phase ends: Discard Strange Geometry and move each investigator and enemy here to the location with the most clues. Each investigator who moved by this effect takes 1 damage and 1 horror.θ If Strange Geometry has no clues on it: Move to any revealed location." />
+      <property name="Shroud" value="4" />
+      <property name="Clues" value="1" />
+    </card>
+    <card id="553e10ea-a80c-435e-8db0-b2ddda222b60" name="Meddlesome Familiar" size="EncounterCard">
+      <property name="Card Number" value="143" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse." />
+      <property name="Text" value="Revelation – If Brown Jenkin is not in play, search the encounter deck and discard pile for him, spawn him at your location, and take 1 damage. Otherwise, search the encounter deck and discard pile for a Swarm of Rats, spawn it engaged with you, then take 1 damage." />
+    </card>
+    <card id="5bc1ba5c-2aa1-469f-abc0-977b3014866e" name="Ghostly Presence" size="EncounterCard">
+      <property name="Card Number" value="144" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Omen." />
+      <property name="Text" value="Revelation –  If Nahab is in play, ready her, resolve her hunter keyword, and she attacks each investigator at her location. If Nahab is at the Site of the Sacrifice, place 1 doom on her, as well. Otherwise, search the encounter deck and discard pile for Nahab and spawn her at your location." />
+    </card>
+    <card id="06c8dd37-39da-4094-8e10-1b02fcc02030" name="Extradimensional Visions" size="EncounterCard">
+      <property name="Card Number" value="145" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Hex." />
+      <property name="Text" value="Revelation – Test ά (2). This test gets +1 difficulty for every 10 cards in the encounter discard pile. If you fail, discard an asset you control." />
+    </card>
+    <card id="95a1ad3a-5ef9-4fac-a751-cfa368756eca" name="Pulled by the Stars" size="EncounterCard">
+      <property name="Card Number" value="146" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Hex." />
+      <property name="Text" value="Revelation – Put Pulled by the Stars into play in your threat area.Forced – At the end of your turn, if you did not move at least once during your turn: Take 2 horror.η: Test ά (3). If you succeed, discard Pulled by the Stars from play. If there is an exhausted Witch enemy at your location, this test is automatically successful." />
+    </card>
+    <card id="5039b791-2c6c-444e-a866-fa11a6e4ed1e" name="Disquieting Dreams" size="EncounterCard">
+      <property name="Card Number" value="147" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Terror." />
+      <property name="Text" value="Revelation – Test ά (5). If you fail, put Disquieting Dreams into play in your threat area.Forced – At the end of your turn: Discard the top card of the encounter deck.Forced – When the encounter deck runs out of cards: Discard Disquieting Dreams and reveal the top 10 cards of your deck. Draw each weakness revealed and discard each other revealed card." />
+    </card>
+    <card id="254213cb-2db4-4dd5-b74e-a2dee3b8d711" name="Brown Jenkin" size="EncounterCard">
+      <property name="Card Number" value="148" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="The Witch's Familiar" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Creature. Familiar. Elite." />
+      <property name="Text" value="Aloof. Hunter.Each ready Creature enemy gets +2 fight.Forced – When the enemy phase ends, if Brown Jenkin is ready: Each investigator at his location discards his or her hand, then draws that many cards." />
+      <property name="Health" value="1" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="4" />
+      <property name="Unique" value="*" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="809ab85e-3f52-414a-876b-7af4a4e53749" name="Nahab" size="EncounterCard">
+      <property name="Card Number" value="149" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="She Who Signed the Black Book" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Witch. Elite." />
+      <property name="Text" value="Hunter. Retaliate.Do not remove doom from Nahab when the agenda advances.Nahab gets +X fight, where X is the number of the current agenda.Forced – After the enemy phase begins, if Nahab is ready: Place 1 doom on her." />
+      <property name="Health" value="1π" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="3" />
+      <property name="Unique" value="*" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="2" />
+    </card>
+    <card id="9c363593-d0df-48a1-a904-9c6ebdc8281b" name="The Black Book">
+      <property name="Card Number" value="150" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Secret Name" />
+      <property name="Subtitle" value="Signed in Blood" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tome. Relic." />
+      <property name="Text" value="You get +1 ά and +1 έ.ι When you play a card, exhaust The Black Book and take X horror: Reduce that card’s cost by X." />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Unique" value="*" />
+      <property name="Skill Icons" value="άέΰ" />
+    </card>
+  </cards>
+</set>

--- a/o8g/Sets/The Wages of Sin/set.xml
+++ b/o8g/Sets/The Wages of Sin/set.xml
@@ -1,0 +1,611 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<set gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" id="8c952b31-6bd1-429f-9c42-6f37b55cce51" name="The Wages of Sin" standalone="True" version="1.0.0" xmlns:noNamespaceSchemaLocation="CardSet.xsd">
+  <cards>
+    <card id="57dbad8a-4250-46ff-9173-f134f3c0c788" name="Alice Luxley">
+      <property name="Card Number" value="151" />
+      <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Fearless Flatfoot" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Detective. Police." />
+      <property name="Text" value="You get +1 έ.ι After you discover a clue, exhaust Alice Luxley: Deal 1 damage to an enemy at your location." />
+      <property name="Health" value="2" />
+      <property name="Sanity" value="2" />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="4" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Unique" value="*" />
+      <property name="Skill Icons" value="έ" />
+    </card>
+    <card id="1a663504-1aef-4631-857c-b754622ce706" name="Well-Maintained">
+      <property name="Card Number" value="152" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Upgrade." />
+      <property name="Text" value="Fast. Play only during your turn.Attach to an Item asset you control. Limit 1 per asset.ι After attached asset is discarded: Return it to its owner’s hand, along with each other Upgrade attachment that was attached to it." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="1" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="ί" />
+    </card>
+    <card id="7d69d529-8921-4ab8-94d6-9602ef6aee5a" name="Mr. “Rook”">
+      <property name="Card Number" value="153" />
+      <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Dealer in Secrets" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally." />
+      <property name="Text" value="Uses (3 secrets).θ Exhaust Mr. “Rook” and spend 1 secret: Search the top 3, 6, or 9 cards of your deck for any card and draw it. If at least 1 weakness is among the searched cards, draw 1 of them, as well. Shuffle your deck." />
+      <property name="Health" value="2" />
+      <property name="Sanity" value="2" />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Unique" value="*" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="61112dca-e602-47b9-af2e-626da3374814" name="Hawk-Eye Folding Camera">
+      <property name="Card Number" value="154" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tool." />
+      <property name="Text" value="ι After the last clue is discovered from your location: Place 1 resource (from the token pool) on this card, as evidence. (Limit once per game at each location.)While Hawk-Eye Folding Camera has……1 or more evidence, you get +1 ά.…2 or more evidence, you get +1 έ.…3 or more evidence, you get +1 sanity." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="9ad7df7c-2878-4171-aacc-4327851265f7" name="Henry Wan">
+      <property name="Card Number" value="155" />
+      <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Aspiring Actor" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Criminal." />
+      <property name="Text" value="η Exhaust Henry Wan: One at a time, reveal random tokens from the chaos bag until you choose to stop, or until you reveal a α, β, γ, δ, or ζ symbol. —If you chose to stop, for each token revealed via this effect, you may either draw 1 card or gain 1 resource.—If you revealed a α, β, γ, δ, or ζ symbol, do nothing." />
+      <property name="Health" value="1" />
+      <property name="Sanity" value="2" />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="Ally" />
+      <property name="Unique" value="*" />
+      <property name="Skill Icons" value="ί" />
+    </card>
+    <card id="8d4c471c-a087-45ab-bfb0-7fcfb86d1644" name="Swift Reflexes">
+      <property name="Card Number" value="156" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Gambit." />
+      <property name="Text" value="Fast. Play during any investigator’s turn, except during an action.Immediately take an action as if it were your turn. This action does not count toward the number of actions you can take each turn." />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="άί" />
+    </card>
+    <card id="bd56131b-3caf-439c-a6ac-c36aaea643f6" name="Wither">
+      <property name="Card Number" value="157" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="η: Fight. This attack uses ά instead of ή. If a α, β, γ, or δ symbol is revealed during this attack, the attacked enemy gets –1 fight and –1 evade for the remainder of the turn (to a minimum of 1)." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Arcane" />
+      <property name="Skill Icons" value="ή" />
+    </card>
+    <card id="7a495d34-c4c0-4e04-bcec-2a31d0799963" name="Sixth Sense">
+      <property name="Card Number" value="158" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="η: Investigate. Investigate using ά instead of έ. If a α, β, γ, or δ symbol is revealed during this test, you may choose a revealed location connected to your location; you are now investigating as if you were at the chosen location instead of your location (you may use either shroud value)." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Arcane" />
+      <property name="Skill Icons" value="έ" />
+    </card>
+    <card id="e723c262-3e6b-4e60-a464-377dbc29a45f" name="Drawing Thin">
+      <property name="Card Number" value="159" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Talent." />
+      <property name="Text" value="ι When you initiate a skill test, exhaust Drawing Thin: Increase the difficulty of this test by 2. Gain 2 resources or draw 1 card." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="87c50b4e-df97-4ce2-ada6-dede98b4b284" name="Belly of the Beast">
+      <property name="Card Number" value="160" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Gambit. Trick." />
+      <property name="Text" value="Fast. Play after you successfully evade an enemy by 2 or more.Discover 1 clue at that enemy’s location." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="άί" />
+    </card>
+    <card id="a263c7a7-7641-479b-bb07-926c93371e15" name="The Wages of Sin" size="EncounterCard">
+      <property name="Card Number" value="161" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Subtitle" value="EASY / STANDARD" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –X. X is 1 higher than the number of copies of Unfinished Business in the victory display.β: –3. Until the end of the round, each Heretic enemy in play gets +1 fight and +1 evade.γ: –3. If you fail, trigger the forced ability on a copy of Unfinished Business in your threat area as if it were the end of the round.δ: –2. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location." />
+      <alternate name="The Wages of Sin" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Subtitle" value="HARD / EXPERT" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –X. X is the number of copies of Unfinished Business in the victory display. Reveal another token.β: –4. Until the end of the round, each Heretic enemy in play gets +1 fight and +1 evade.γ: –4. If you fail, trigger the forced ability on a copy of Unfinished Business in your threat area as if it were the end of the round.δ: –2. If this is an attack or evasion attempt, resolve each haunted ability on your location." />
+      </alternate>
+    </card>
+    <card id="c649bd6a-77f3-4ef1-8dfc-b20c0a034702" name="THE HANGED MAN · XII" size="HorizCard">
+      <property name="Card Number" value="162" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Subtitle" value="Agenda 1a" />
+      <property name="Type" value="Agenda" />
+      <property name="Doom" value="8" />
+      <alternate name="Death's Descent" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Subtitle" value="Agenda 1b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="The sobs of the dead echo throughout the woods, accompanied by murmured promises and whispered threats. But when the spectral mist blots out the sky, all turns quiet and still. Your hair stands on end, and you begin to tremble. Every fiber of your being screams flight.The hunter has smelled the blood of its prey, and now it has come to claim your fate.Flip each location to its Spectral side.Put the set-aside The Spectral Watcher enemy into play at Hangman’s Brook.Shuffle the remainder of the set-aside The Watcher encounter set into the spectral encounter deck, along with the spectral discard pile." />
+      </alternate>
+    </card>
+    <card id="ef33243d-ba84-495f-9eb8-2efc9e1a98f5" name="Death’s Approach" size="HorizCard">
+      <property name="Card Number" value="163" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Subtitle" value="Agenda 2a" />
+      <property name="Type" value="Agenda" />
+      <property name="Text" value="Locations cannot be flipped over." />
+      <property name="Doom" value="7" />
+      <alternate name="Death’s Embrace" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Subtitle" value="Agenda 2b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="Light fades as the anomaly closes in around you. Trees, graves, walls—all is enveloped by the otherworldly mist. Deep in the murk, worlds away and yet drawing ever closer, the cold light of the watcher’s gaze radiates before you. It is time for your reckoning.(-&gt;R2)" />
+      </alternate>
+    </card>
+    <card id="f7a92c70-67d6-413e-8e02-28503af28dfa" name="In Pursuit of the Dead" size="HorizCard">
+      <property name="Card Number" value="164" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Subtitle" value="Act 1a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Locations cannot be flipped over." />
+      <alternate name="The Barrier Between" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Subtitle" value="Act 1b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Soft chanting guides you to a gloomy clearing near the abandoned chapel. A circle of witchweed surrounds the clearing, swaying gently in the breeze. At the center of the clearing, a cloaked woman kneels in front of an unmarked grave, far from the remainder of the graveyard. You watch in quiet for a few minutes while the woman sings an old, somber melody. It reminds you somewhat of a child’s lullaby – soothing, but with a dark gravity that betrays its purpose. As soon as the song ends, the woman’s cloak dissolves into mist, and she vanishes in a swirl of shadows.Spawn 1 set-aside Heretic enemy at each of the following locations: The Gallows, Heretics’ Graves, Chapel Attic, and Chapel Crypt.Add 2π clues to each of those locations. Add 1π clues to each other location in play.Check Campaign Log. If you have 3 or more Mementos under “Mementos Discovered:” You understand the tragic lyrics behind the witch’s song. Each investigator puts into play 1 set-aside Spectral Web asset, under his or her control." />
+        <property name="Clues" value="3π" />
+      </alternate>
+    </card>
+    <card id="9248442d-eacd-4813-9bb2-142b4fd7dd27" name="In Pursuit of the Living" size="HorizCard">
+      <property name="Card Number" value="165" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Subtitle" value="Act 2a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ: Flip your location over. (Group limit once per round at each location.)Clues cannot be discovered at non-Spectral locations. Objective – Banish as many Heretics as you can. If there are 4 copies of Unfinished Business in the victory display, advance." />
+      <alternate name="Was It Worth It?" size="HorizCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Subtitle" value="Act 2b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="When the last of the ghosts vanishes, she leaves behind a remembrance: something which does not fade along with the rest of her ephemeral form. Curious, you step forward and examine the object. It is a corn husk doll wearing a black cloak, with locks of hair made of red‑dyed yarn. You’re not sure what significance the doll holds, if any...but nonetheless, a pyrrhic truth speaks to you from its expressionless face.“Was it worth it?” The doll seems to say.In your Campaign Log, under “Mementos Discovered,” record Corn Husk Doll.(-&gt;R1)" />
+      </alternate>
+    </card>
+    <card id="3353c57b-4def-4ddb-93bc-5c58ec8be27c" name="Hangman’s Brook" size="EncounterCard">
+      <property name="Card Number" value="166" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="η: Resign. “Whose bright idea was this, anyway?”" />
+      <property name="Shroud" value="4" />
+      <property name="Clues" value="1π" />
+      <alternate name="Hangman’s Brook" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="η: Resign. “Whose bright idea was this, anyway?”Haunted – Take 1 damage. Until the end of the round, the above resign ability cannot be triggered." />
+        <property name="Shroud" value="4" />
+      </alternate>
+    </card>
+    <card id="f4971a44-74c0-430f-9d84-374ca224ca57" name="Haunted Fields" size="EncounterCard">
+      <property name="Card Number" value="167" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="Each Spectral enemy at Haunted Fields gets +1 horror value." />
+      <property name="Shroud" value="3" />
+      <property name="Clues" value="2π" />
+      <property name="Victory Points" value="1" />
+      <alternate name="Haunted Fields" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="Each Spectral enemy at Haunted Fields gets +1 horror value.Haunted – Move the nearest Spectral enemy once toward Haunted Fields." />
+        <property name="Shroud" value="3" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="05e49566-9511-43e5-8304-41754b33a5ca" name="Abandoned Chapel" size="EncounterCard">
+      <property name="Card Number" value="168" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="During the mythos phase, each investigator in Abandoned Chapel gets –1 to each skill." />
+      <property name="Shroud" value="2" />
+      <property name="Clues" value="2π" />
+      <property name="Victory Points" value="1" />
+      <alternate name="Abandoned Chapel" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="During the mythos phase, each investigator in Abandoned Chapel gets –1 to each skill.Haunted – Until the end of the round, you get –1 to each skill." />
+        <property name="Shroud" value="2" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="e22800b9-b238-4887-8289-35cf0c978363" name="The Gallows" size="EncounterCard">
+      <property name="Card Number" value="169" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="The Gallows gets +1 shroud for each Witch enemy in play." />
+      <property name="Shroud" value="3" />
+      <alternate name="The Gallows" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="The Gallows gets +1 shroud for each Witch enemy in play.Haunted – Discard the top 3 cards of the standard encounter deck. If a Witch enemy is discarded by this effect, draw it." />
+        <property name="Shroud" value="3" />
+      </alternate>
+    </card>
+    <card id="028d377a-a1ad-44ee-91f7-ee1baa5210c2" name="The Gallows" size="EncounterCard">
+      <property name="Card Number" value="170" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="X is the number of Geist enemies in play." />
+      <property name="Shroud" value="X" />
+      <alternate name="The Gallows" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="X is the number of Geist enemies in play.Haunted – Discard the top 3 cards of the spectral encounter deck. If a Geist enemy is discarded by this effect, draw it." />
+        <property name="Shroud" value="X" />
+      </alternate>
+    </card>
+    <card id="68d6765d-2d4d-4882-be2a-9d569ef2e662" name="Heretics’ Graves" size="EncounterCard">
+      <property name="Card Number" value="171" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="While investigating Heretics’ Graves, add your ά value to your skill value for the investigation." />
+      <property name="Shroud" value="7" />
+      <alternate name="Heretics’ Graves" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="While investigating Heretics’ Graves, add your ά value to your skill value for the investigation.Haunted – Reduce your base ά to 1 until the end of your next turn." />
+        <property name="Shroud" value="7" />
+      </alternate>
+    </card>
+    <card id="d54acf40-23db-4210-bd8d-a1aa9ee84ad1" name="Heretics’ Graves" size="EncounterCard">
+      <property name="Card Number" value="172" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="Forced – After a Witch enemy at Heretics’ Graves is defeated: Discard the top 2 cards of the standard encounter deck." />
+      <property name="Shroud" value="4" />
+      <alternate name="Heretics’ Graves" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="Forced – After a Witch enemy at Heretics’ Graves is defeated: Discard the top 2 cards of the standard encounter deck.Haunted – Heal 1 damage from each Heretic and each Witch enemy in play." />
+        <property name="Shroud" value="4" />
+      </alternate>
+    </card>
+    <card id="4adf6b60-a149-458e-b677-fb9c1662d719" name="Chapel Crypt" size="EncounterCard">
+      <property name="Card Number" value="173" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="While there are no ready enemies at Chapel Crypt, it gets –3 shroud." />
+      <property name="Shroud" value="6" />
+      <alternate name="Chapel Crypt" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="While there are no ready enemies at Chapel Crypt, it gets –3 shroud.Haunted – Spawn the top card of your deck facedown, engaged with you. Treat that card as a Reanimated Dead enemy with 1 fight, 1 health, 1 evade, 1 damage, and the Monster trait." />
+        <property name="Shroud" value="6" />
+      </alternate>
+    </card>
+    <card id="949842f1-b1f1-46da-8656-0357e77df332" name="Chapel Crypt" size="EncounterCard">
+      <property name="Card Number" value="174" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="While there are no Hex treacheries among investigators’ threat areas at Chapel Crypt, it gets –3 shroud." />
+      <property name="Shroud" value="6" />
+      <alternate name="Chapel Crypt" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="While there are no Hex treacheries among investigators’ threat areas at Chapel Crypt, it gets –3 shroud.Haunted – Find the topmost Hex treachery in the standard encounter discard pile and put it into play in your threat area." />
+        <property name="Shroud" value="6" />
+      </alternate>
+    </card>
+    <card id="8b5a93f4-6782-4263-92cd-0c141e6ffb7d" name="Chapel Attic" size="EncounterCard">
+      <property name="Card Number" value="175" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="Forced – After you draw a non-weakness card from your deck while at Chapel Attic: Place that card facedown beneath Chapel Attic, out of play.ι After you successfully investigate Chapel Attic: Add each card beneath it to its owner’s hand." />
+      <property name="Shroud" value="4" />
+      <alternate name="Chapel Attic" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="Forced – After you draw a non-weakness card from your deck while at Chapel Attic: Place that card facedown beneath Chapel Attic, out of play.ι After you successfully investigate Chapel Attic: Add each card beneath it to its owner’s hand." />
+        <property name="Shroud" value="4" />
+      </alternate>
+    </card>
+    <card id="ea209a3c-ba80-469e-9966-f01d35a550d1" name="Chapel Attic" size="EncounterCard">
+      <property name="Card Number" value="176" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Location" />
+      <property name="Text" value="While investigating Chapel Attic, add the number of cards in your hand to your skill value for the investigation." />
+      <property name="Shroud" value="8" />
+      <alternate name="Chapel Attic" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Spectral" />
+        <property name="Text" value="While investigating Chapel Attic, add the number of cards in your hand to your skill value for the investigation.Haunted – Discard a random card from your hand (2 cards instead of you have 5 or more cards in hand)." />
+        <property name="Shroud" value="8" />
+      </alternate>
+    </card>
+    <card id="11b99268-8d50-4863-9b24-7aa2f2f3f0ef" name="Spectral Web">
+      <property name="Card Number" value="177" />
+      <property name="Quantity" value="4" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Spell." />
+      <property name="Text" value="η Investigators at your location spend 1–3 clues, as a group: Fight. Use this ability only to attack a  enemy. You may choose to use your ά instead of your ή for this attack. You get +X skill value and deal +X damage for this attack, where X is the amount of clues spent to trigger this ability." />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="" />
+    </card>
+    <card id="2b3aadab-97d4-4ea9-91a5-bd40534805f9" name="Heretic" size="EncounterCard">
+      <property name="Card Number" value="178" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Witch. Spectral. Elite." />
+      <property name="Text" value="Heretic gets +2π health.While Heretic is at a non-Spectral location, it gains aloof and cannot be engaged or damaged.θ Spend 1 clue: Parley. Look at Heretic’s other side (without resolving its text).Forced – After Heretic is defeated: Flip it over and resolve the text on its other side." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <alternate name="Unfinished Business" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="Bring me to him... I wish to see my love again...The thing moans and wails with sorrow, in between hollow, echoing sobs. There must be some way you can bring it peace.Keep this card in your threat area (this side faceup).Forced – At the end of the round: You must either take 1 horror or flip this card back to its enemy side.η If you are at Chapel Crypt and it has no clues on it: Test έ or ή (4). If you succeed, the ghost is “banished” (resolve the text below).––––––––––––––––––––––––––––––––––––––––––Do not read until this ghost is “banished.”You find a nameless coffin and remove the lid. The spirit weeps as it reaches out to touch the body inside, remembering the love it once held in its heart.Add this card to the victory display." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="b3ca52b8-7d20-4f74-a57d-0b65edd6d610" name="Heretic" size="EncounterCard">
+      <property name="Card Number" value="178" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Witch. Spectral. Elite." />
+      <property name="Text" value="Heretic gets +2π health.While Heretic is at a non-Spectral location, it gains aloof and cannot be engaged or damaged.θ Spend 1 clue: Parley. Look at Heretic’s other side (without resolving its text).Forced – After Heretic is defeated: Flip it over and resolve the text on its other side." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <alternate name="Unfinished Business" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="Burn... let it burn... let it all burn...The charred ghost thrashes and howls in agony, as though in a constant state of torment. You cannot ease its suffering, but perhaps you can bring it justice.Keep this card in your threat area (this side faceup).Forced – At the end of the round: You must either take 1 damage or flip this card back to its enemy side.η If you are at The Gallows and it has no clues on it: Test ά or ί (4). If you succeed, the ghost is “banished” (resolve the text below).––––––––––––––––––––––––––––––––––––––––––Do not read until this ghost is “banished.”The fire spreads quickly, consuming the old wooden platform hungrily. The spirit’s form twitches with a strange satisfaction.Add this card to the victory display." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="692f82a8-3fdb-4bb0-b4e4-4cb738482978" name="Heretic" size="EncounterCard">
+      <property name="Card Number" value="178" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Witch. Spectral. Elite." />
+      <property name="Text" value="Heretic gets +2π health.While Heretic is at a non-Spectral location, it gains aloof and cannot be engaged or damaged.θ Spend 1 clue: Parley. Look at Heretic’s other side (without resolving its text).Forced – After Heretic is defeated: Flip it over and resolve the text on its other side." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <alternate name="Unfinished Business" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="They stole it from me... give it back to me...The spirit searches its surroundings frantically and grasps at you with desperate eyes. It must have lost something important—but what?Keep this card in your threat area (this side faceup).Forced – At the end of the round: You must either lose 2 resources or flip this card back to its enemy side.η If you are at Chapel Attic and it has no clues on it: Test έ or ί (4). If you succeed, the ghost is “banished” (resolve the text below).––––––––––––––––––––––––––––––––––––––––––Do not read until this ghost is “banished.”In an old cobwebbed trunk, you find all sorts of items belonging to the deceased. The sight of a crow skull amulet dipped in metal causes the ghost to gasp. “I’m sorry, sister, I’m sorry…” it weeps.Add this card to the victory display." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="b1b9b253-81ec-4429-85f3-44641924844d" name="Heretic" size="EncounterCard">
+      <property name="Card Number" value="178" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Witch. Spectral. Elite." />
+      <property name="Text" value="Heretic gets +2π health.While Heretic is at a non-Spectral location, it gains aloof and cannot be engaged or damaged.θ Spend 1 clue: Parley. Look at Heretic’s other side (without resolving its text).Forced – After Heretic is defeated: Flip it over and resolve the text on its other side." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <alternate name="Unfinished Business" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="my bones... what have they done to mY bones...The wraith is mangled and corrupted nearly beyond recognition. Something has torn through its insides and ripped its soul to shreds.Keep this card in your threat area (this side faceup).Forced – At the end of the round: You must either choose and discard 2 cards from your hand or flip this card back to its enemy side.η If you are at Heretics’ Graves and it has no clues on it: Test ά or ή (4). If you succeed, the ghost is “banished” (resolve the text below).––––––––––––––––––––––––––––––––––––––––––Do not read until this ghost is “banished.”Digging up the bones was hard work, but as the spirit peers into its open grave, you can see its humanoid shape clearly for the first time.Add this card to the victory display." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="2db09a66-5db7-4e52-8e91-0eed039312cb" name="Heretic" size="EncounterCard">
+      <property name="Card Number" value="178" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Witch. Spectral. Elite." />
+      <property name="Text" value="Heretic gets +2π health.While Heretic is at a non-Spectral location, it gains aloof and cannot be engaged or damaged.θ Spend 1 clue: Parley. Look at Heretic’s other side (without resolving its text).Forced – After Heretic is defeated: Flip it over and resolve the text on its other side." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <alternate name="Unfinished Business" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="come... Join us...The specter’s voice is soothing and melodic. Its words seem to make sense. You can at last be at peace—all you have to do is take its hand.Flip this card back to its enemy side. It makes an immediate attack. For the remainder of the scenario, this enemy cannot be defeated by any means, its parley ability can only be activated while at a Spectral location, and it costs +1π clues to trigger. The next time this side is resolved, the ghost is “banished” instead (resolve the text below).Forced – If you looked at this side by resolving this Heretic’s parley ability: Resolve the above text as though you had just defeated this Heretic.––––––––––––––––––––––––––––––––––––––––––Do not read until this ghost is “banished.”You spurn the creature’s offer, remembering once more why you have come here. It lets out an agonizing shriek and returns from whence it came.Add this card to the victory display." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="c2e303a2-88fa-40b4-aba3-eeb7f65f136f" name="Heretic" size="EncounterCard">
+      <property name="Card Number" value="178" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Witch. Spectral. Elite." />
+      <property name="Text" value="Heretic gets +2π health.While Heretic is at a non-Spectral location, it gains aloof and cannot be engaged or damaged.θ Spend 1 clue: Parley. Look at Heretic’s other side (without resolving its text).Forced – After Heretic is defeated: Flip it over and resolve the text on its other side." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="4" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+      <alternate name="Unfinished Business" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="The Wages of Sin" />
+        <property name="Type" value="Story" />
+        <property name="Text" value="I can’t be dead... Keziah promised... we cannot die...The spiteful wraith does not relent. Your words cannot reach it, but perhaps you can lay it to rest by force.Flip this card back to its enemy side. It makes an immediate attack. The next time it is defeated, it is “banished” (resolve the text below).Forced – If you looked at this side by resolving this Heretic’s parley ability: Flip this card back to its enemy side. It makes an immediate attack. (Do not resolve any other text on this card.)––––––––––––––––––––––––––––––––––––––––––Do not read until this ghost is “banished.”With a final cry, the hellish spirit recoils upon itself and dissipates into thin air.Add this card to the victory display." />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="ff76e088-1395-4e10-8a43-17de4c914049" name="Vengeful Witch" size="EncounterCard">
+      <property name="Card Number" value="179" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Humanoid. Witch." />
+      <property name="Text" value="Spawn – The Gallows or Heretics’ Graves.Alert. Hunter.Forced – When Vengeful Witch is defeated: Deal its damage and horror to each investigator at its location, as direct damage/horror." />
+      <property name="Health" value="3" />
+      <property name="Combat" value="3" />
+      <property name="Agility" value="3" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="1dafb518-3669-4a12-8f27-6b0a6335227f" name="Malevolent Spirit" size="EncounterCard">
+      <property name="Card Number" value="180" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Monster. Geist. Spectral." />
+      <property name="Text" value="Spawn – Chapel Attic or Chapel Crypt.While Malevolent Spirit is at a Spectral location, it gains hunter and gets +1 damage value and +1 horror value.Forced – When Malevolent Spirit is defeated by damage (except from a Spell or Relic): Instead of discarding it, heal all damage from it, exhaust it, and move it to any Spectral location, if able." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="4" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="051bcbce-880a-4a89-a41c-48e6dc451815" name="Punishment" size="EncounterCard">
+      <property name="Card Number" value="181" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Hex." />
+      <property name="Text" value="Revelation – Put Punishment into play in your threat area.Forced – After an enemy at any location is defeated: Take 1 damage.η: Test ά (3). If you succeed, discard Punishment. If there is an exhausted Witch enemy at your location, this test is automatically successful." />
+    </card>
+    <card id="6709f629-17f6-42bf-aa4a-f106840e8ae9" name="Burdens of the Past" size="EncounterCard">
+      <property name="Card Number" value="182" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse. Spectral." />
+      <property name="Text" value="Revelation – If there are no copies of Unfinished Business in your threat area, Burdens of the Past gains surge. Otherwise, trigger the forced ability of each copy of Unfinished Business in your threat area as if it were the end of the round." />
+    </card>
+    <card id="288969bc-3df6-431e-b04d-f0d150af3be4" name="Ominous Portents" size="EncounterCard">
+      <property name="Card Number" value="183" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Omen." />
+      <property name="Text" value="Peril.Revelation – You must either (choose one): —Draw the top card of the spectral encounter deck. That card gains peril, and its effects cannot be canceled.—Test ά (3). If you fail, take 2 horror." />
+    </card>
+    <card id="1529b14f-ab18-4db9-841a-b0b603f1efde" name="Grave-light" size="EncounterCard">
+      <property name="Card Number" value="184" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse." />
+      <property name="Text" value="Revelation – If Grave-Light is drawn......from the standard encounter deck, shuffle it into the spectral encounter deck, and it gains surge....from the spectral encounter deck, take 2 damage and place it in the standard encounter discard pile." />
+    </card>
+    <card id="fe1d32d4-ba8e-49ae-b0a4-58b4a207c453" name="Bane of the Living" size="EncounterCard">
+      <property name="Card Number" value="185" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="The Wages of Sin" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse. Spectral." />
+      <property name="Text" value="Peril.Revelation – You must either (choose one):–Choose an Unfinished Business card in play, flip it to its Heretic side, and place damage on it equal to half its health.–Discard cards from the top of the spectral encounter deck until a  enemy is discarded. Spawn that enemy engaged with you." />
+    </card>
+  </cards>
+</set>

--- a/o8g/Sets/Union and Disillusion/set.xml
+++ b/o8g/Sets/Union and Disillusion/set.xml
@@ -1,0 +1,689 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<set gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" id="5d37e9c1-1737-4b9e-8ae9-c649b30582bc" name="Union and Disillusion" standalone="True" version="1.0.0" xmlns:noNamespaceSchemaLocation="CardSet.xsd">
+  <cards>
+    <card id="00776fb1-44a1-4419-820d-67f52d2f9b10" name="Warning Shot">
+      <property name="Card Number" value="229" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Tactic. Trick." />
+      <property name="Text" value="As an additional cost to play Warning Shot, spend 1 ammo from a Firearm asset you control.Move all non-Elite enemies at your location to a connecting location. This action does not provoke attacks of opportunity." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="ήί" />
+    </card>
+    <card id="d5b0032a-c405-4564-a4a4-afedd20df99b" name="Telescopic Sight">
+      <property name="Card Number" value="230" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Item. Upgrade." />
+      <property name="Text" value="Fast. Attach to a Firearm asset you control that takes up two hand slots. Attached asset cannot be used to attack enemies engaged with you.ι When you perform a Fight action using attached asset, if you are engaged with no enemies, exhaust Telescopic Sight: This attack can target a non-Elite enemy at a connecting location. Ignore the aloof and retaliate keywords for this attack." />
+      <property name="Class" value="Guardian" />
+      <property name="Level" value="3" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="1" />
+      <property name="Skill Icons" value="έήί" />
+    </card>
+    <card id="89bc2232-5465-41e0-8ed9-3fccd32eb904" name="Knowledge is Power">
+      <property name="Card Number" value="231" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Insight." />
+      <property name="Text" value="Fast. Play only during your turn.Choose a Tome or Spell asset you control, or reveal a Tome or Spell asset from your hand. Resolve an η or θ ability on that asset, ignoring all costs (including its η cost, if any). Then, if that asset was in your hand, you may discard it to draw 1 card." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="0" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="άέ" />
+    </card>
+    <card id="95cec491-6fd7-4d2c-a0f8-e0d4e0b0ec74" name="Esoteric Atlas">
+      <property name="Card Number" value="232" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tome." />
+      <property name="Text" value="Uses (4 secrets).η Spend 1 secret and exhaust Esoteric Atlas: Choose a revealed location that is exactly 2 connections away from your location. Move to that location." />
+      <property name="Class" value="Seeker" />
+      <property name="Level" value="1" />
+      <property name="Cost" value="3" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="ί" />
+    </card>
+    <card id="9d070e2e-8347-4dee-862c-3ef2cad34aed" name="Investments">
+      <property name="Card Number" value="233" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Connection." />
+      <property name="Text" value="Uses (0 supplies). Limit 10 supplies on Investments.θ Exhaust Investments: Place 1 supply on it.η Exhaust and discard Investments: Move all supplies from it to your resource pool, as resources." />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="έ" />
+    </card>
+    <card id="6eab252a-1fe5-4d43-a849-7c05882d21ba" name="Decoy">
+      <property name="Card Number" value="234" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Favor. Service." />
+      <property name="Text" value="Evade. Automatically evade a non-Elite enemy at your location.ι When you play Decoy, increase its cost by 2: Change “a non-Elite enemy” to “up to 2 non-Elite enemies.”ι When you play Decoy, increase its cost by 2: Change “at your location” to “at a location up to 2 connections away.”" />
+      <property name="Class" value="Rogue" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="2" />
+      <property name="Skill Icons" value="ίί" />
+    </card>
+    <card id="691217c3-4d2b-4657-a773-29cec6140909" name="De Vermis Mysteriis">
+      <property name="Card Number" value="235" />
+      <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Signs of the Black Stars" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Item. Tome." />
+      <property name="Text" value="η Exhaust De Vermis Mysteriis and place 1 doom on it: Play a Spell or Insight event from your discard pile, reducing its resource cost by 1. After that event resolves, remove it from the game." />
+      <property name="Class" value="Mystic" />
+      <property name="Level" value="2" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="1 Hand" />
+      <property name="Skill Icons" value="έ" />
+    </card>
+    <card id="bcd654ff-e2ce-4096-adf3-cca425a45b05" name="Guiding Spirit">
+      <property name="Card Number" value="236" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Geist." />
+      <property name="Text" value="You get +1 [έ].Non-direct horror must be assigned to Guiding Spirit before it can be assigned to your investigator card.Forced – After Guiding Spirit is defeated by horror: Exile it." />
+      <property name="Health" value="–" />
+      <property name="Sanity" value="3" />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="1" />
+      <property name="Cost" value="1" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="ά" />
+    </card>
+    <card id="2f4e9f88-1f3e-47a8-8266-f6fa88276e97" name="Fortune or Fate">
+      <property name="Card Number" value="237" />
+      <property name="Quantity" value="2" />
+      <property name="Type" value="Event" />
+      <property name="Traits" value="Fortune. Blessed." />
+      <property name="Text" value="Fast. Play when doom would be placed on any scenario card.Max 1 per game.Cancel 1 doom just placed on that card. Exile Fortune or Fate." />
+      <property name="Class" value="Survivor" />
+      <property name="Level" value="2" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Skill Icons" value="ΰ" />
+    </card>
+    <card id="1585647b-56d3-4856-bd37-76fde6b807c7" name="Union and Disillusion" size="EncounterCard">
+      <property name="Card Number" value="238" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="EASY / STANDARD" />
+      <property name="Type" value="Scenario" />
+      <property name="Text" value="α: –2. If this is a skill test during a circle action, reveal another token.β: –3. If you have no damage on you, take 1 damage. If you have no horror on you, take 1 horror.γ: –3. If you fail, a Spectral enemy at your location attacks you (even if it is exhausted).δ: –3. If this is a skill test during a circle action and you fail, resolve each haunted ability on your location." />
+      <alternate name="Union and Disillusion" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="HARD / EXPERT" />
+        <property name="Type" value="Scenario" />
+        <property name="Text" value="α: –3. If this is a skill test during a circle action, reveal another token.β: –4. If you have no damage on you, take 1 damage. If you have no horror on you, take 1 horror.γ: –4. If you fail, a Spectral enemy at your location attacks you (even if it is exhausted).δ: –4. If this is a skill test during a circle action and you fail, resolve each haunted ability on your location." />
+      </alternate>
+    </card>
+    <card id="0a42e490-8234-4f13-a2ed-3275b2d82325" name="THE LOVERS · VI" size="HorizCard">
+      <property name="Card Number" value="239" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Agenda 1a" />
+      <property name="Type" value="Agenda" />
+      <property name="Doom" value="8" />
+      <alternate name="Stolen Souls" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Agenda 1b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="The mist obscures the moon, plunging the woods into darkness. A flock of birds suddenly scatter from the treetops.Shuffle the encounter discard pile into the encounter deck.———————Check the “Missing Persons” section of the Campaign Log. If at least 1 character was “taken by the watcher,” read the following:Beyond the spectral mist, an awful scream resounds through the woods. It is distant, as though heard through a pane of glass, but distinct enough for you to know it is real. For each character who was taken by the watcher, place 1 resource on The Spectral Watcher, as a stolen soul (even if The Spectral Watcher is currently out of play).Until the end of the scenario, The Spectral Watcher gains the following text: “For each stolen soul on The Spectral Watcher, it gets +1 fight and +1π health.” Keep this card next to the agenda deck as a reminder, and advance to agenda 2a." />
+      </alternate>
+    </card>
+    <card id="c728e562-199b-4f9e-a54e-c2ff2f7f3088" name="Crossroads of Fate" size="HorizCard">
+      <property name="Card Number" value="240" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Agenda 2a" />
+      <property name="Type" value="Agenda" />
+      <property name="Doom" value="10" />
+      <alternate name="A Victor Emerges" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Agenda 2b" />
+        <property name="Type" value="Agenda" />
+        <property name="Text" value="A powerful gale sweeps through the island from its center, and the spectral pillar marking the site of the Lodge’s ritual suddenly bursts outward. Dozens of specters and phantasmal shapes fly across the treetops and weave through the woods. You will never forget their shrieks, like hundreds of deathcries sounding at once.With a final surge of power, the stone obelisk at the center of the island shatters. Trees bend from the tremendous force that is unleashed, and you are pummeled to the ground. Everything goes black.Each surviving investigator is defeated and suffers 1 physical trauma.(→ R5)" />
+      </alternate>
+    </card>
+    <card id="b0e80ad3-fea9-4b02-a1ca-921f1da17b65" name="The Unvisited Isle" size="HorizCard">
+      <property name="Card Number" value="241" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 1a" />
+      <property name="Type" value="Act" />
+      <alternate name="The Mist Returns" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 1b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="You venture deeper and deeper into the overgrown woods, a timid voice in the back of your mind urging you to flee this place and never return. The dark mist becomes so dense you can hardly see anything. You shout for any of your companions, but there is no response—just the sway of dying tree branches in the wind and the distant thump of your heart pounding in your chest.Each investigator must randomly choose 1 of the set-aside Unvisited Isle locations, put it into play in front of him or her, and immediately move to that location (cannot be canceled). If the investigators sided with the coven, the brazier at each of those locations is already lit. Place a resource token on each of those locations to signify this.Shuffle each of the story cards beneath the scenario reference card and deal 1 at random to each investigator until all of them have been dealt. In player order, resolve each of the dealt story cards." />
+      </alternate>
+    </card>
+    <card id="6127d4b4-147e-446d-95d1-11668ff3a8c7" name="Fated Souls" size="HorizCard">
+      <property name="Card Number" value="242" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 2a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="Each investigator cannot leave the location in front of him or her." />
+      <alternate name="From the Depths" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 2b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="Before long, the revenant arrives. It rises from the depths of the Miskatonic River, unfazed by the water or the mist. Sensing fear and blood, it glides slowly toward the island with its arm outstretched. Its gaze brings dismay. Its grasp brings death.Spawn The Spectral Watcher at the Miskatonic River.Shuffle each set-aside copy of Watcher’s Grasp and Watcher’s Gaze into the encounter deck, along with the encounter discard pile.Return the location in front of each investigator to the center of the play area. (Investigators are no longer prevented from leaving their location.)Put the set-aside The Geist-Trap location into play. If the investigators sided with the coven, the brazier at The Geist-Trap is already lit. Place a resource token on it to signify this." />
+      </alternate>
+    </card>
+    <card id="6ebfafbe-e588-48eb-9bfc-d5f99517a92b" name="Beyond the Mist (v. I)" size="HorizCard">
+      <property name="Card Number" value="243" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 3a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ During a circle action, spend 1 clue: Reduce the difficulty of this skill test by 2.Objective – If each Unvisited Isle location in play is revealed and the brazier on each of them is lit, advance." />
+      <alternate name="Against the Witches" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 3b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="After nearly an hour spent searching through the dense mist, you finally arrive at the site of the Lodge’s ritual, only to find it in chaos. Members of the Silver Twilight Lodge, each wearing robes of blue and silver, are embroiled in battle with the witches. “Complete the ritual!” Carl Sanford commands you from across the clearing. “It is the only way!” Anette turns her attention to you, shocked and angered. “You again! I warned you we would not show mercy if we met a second time.” She calls to her coven: “Sisters! We must not let them interfere this time. Do not let their circle close!”Reveal The Geist-Trap location. Move each investigator at an Unvisited Isle location to The Geist-Trap.Check Campaign Log. If the witches’ spell was cast, spawn the set-aside Anette Mason at The Geist-Trap. If the witches’ spell was broken, spawn 1 set-aside Coven Initiate at The Geist-Trap (2 instead if there are 3 or 4 investigators in the game).Shuffle each remaining set-aside Witch enemy into the encounter deck, along with the encounter discard pile." />
+      </alternate>
+    </card>
+    <card id="efbe7666-ffae-44dd-9958-893a2ec90d4d" name="Beyond the Mist (v. II)" size="HorizCard">
+      <property name="Card Number" value="244" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 3a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ During a circle action, spend 1 clue: Reduce the difficulty of this skill test by 2.Objective – If each Unvisited Isle location in play is revealed and the brazier on each of them is unlit, advance." />
+      <alternate name="Loyalty is Earned" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 3b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="After nearly an hour spent searching through the dense mist, you finally arrive at the site of the Lodge’s ritual, only to find it in chaos. Members of the Silver Twilight Lodge, each wearing robes of blue and silver, are embroiled in battle with the witches. “The ritual has neared completion!” Carl Sanford yells to you from across the clearing. “Bring the revenant here and end this!” It is now or never. Glaring at the man, you throw the unlit braziers you snuffed along the way onto the ground, breaking the delicate wards placed upon them. Immediately, the dark mist invades, and hungry shapes in the mist descend upon the unfortunate members of the Lodge. “Traitor!” one yells. You try to ignore their cries of agony as you proceed towards the center of the clearing.Reveal The Geist-Trap location. Move each investigator at an Unvisited Isle location to The Geist-Trap.Remove all β tokens from the chaos bag (even if they are currently sealed on cards in play) for the remainder of the campaign." />
+      </alternate>
+    </card>
+    <card id="f0a7e46e-0754-4068-b868-a01fc790d039" name="Beyond the Mist (v. III)" size="HorizCard">
+      <property name="Card Number" value="245" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 3a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ During a circle action, spend 1 clue: Reduce the difficulty of this skill test by 2.Objective – If each Unvisited Isle location in play is revealed and the brazier on each of them is unlit, advance." />
+      <alternate name="True Colors" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 3b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="After nearly an hour spent searching through the dense mist, you finally arrive at the site of the Lodge’s ritual, only to find it in chaos. Members of the Silver Twilight Lodge, each wearing robes of blue and silver, are embroiled in battle with the witches. “The ritual has neared completion!” Carl Sanford yells to you from across the clearing. “Bring the revenant here and end this!” Glaring at the man, you refuse. “So, at last you show your true colors. I thought that might be the case.” The Lodge’s enforcers turn on you without hesitation.Reveal The Geist-Trap location. Move each investigator at an Unvisited Isle location to The Geist-Trap.Spawn 1 set-aside Lodge Neophyte enemy at The Geist-Trap (2 instead if there are 3 or 4 investigators in the game).Shuffle the remainder of the set-aside Silver Twilight Lodge encounter set into the encounter deck, along with the encounter discard pile.Check Campaign Log. If Josef is alive and well, spawn the set-aside Josef Meiger enemy at The Geist-Trap. Investigators cannot parley with Josef Meiger for the remainder of the game." />
+      </alternate>
+    </card>
+    <card id="e6eb679c-e554-4acd-a1b2-f1982e7e07b5" name="Beyond the Mist (v. IV)" size="HorizCard">
+      <property name="Card Number" value="246" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 3a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ During a circle action, spend 1 clue: Reduce the difficulty of this skill test by 2.Objective – If each Unvisited Isle location in play is revealed and the brazier on each of them is unlit, advance." />
+      <alternate name="Against the Lodge" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 3b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="After nearly an hour spent searching through the dense mist, you finally arrive at the site of the Lodge’s ritual, only to find it in chaos. Members of the Silver Twilight Lodge, each wearing robes of blue and silver, are embroiled in battle with the witches. “The ritual has neared completion!” Carl Sanford yells to you from across the clearing. “Bring the revenant here and end this!” Glaring at the man, you refuse. He looks surprised for a moment, then growls, “So, you are on their side after all. How disappointing.” He turns to his inner circle and commands, “Kill them! Do not let them interfere!”Reveal The Geist-Trap location. Move each investigator at an Unvisited Isle location to The Geist-Trap.Shuffle the set-aside Silver Twilight Lodge encounter set into the encounter deck, along with the encounter discard pile.Check Campaign Log. If Josef is alive and well, spawn the set-aside Josef Meiger enemy at The Geist-Trap. Investigators cannot parley with Josef Meiger for the remainder of the game." />
+      </alternate>
+    </card>
+    <card id="06128107-071b-474e-9fa4-4b3ecb427fe8" name="The Binding Rite" size="HorizCard">
+      <property name="Card Number" value="247" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 4a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ During a circle action, spend 1 clue: Reduce the difficulty of this skill test by 2.Objective – If The Spectral Watcher is defeated at The Geist-Trap while the brazier there is lit, advance." />
+      <alternate name="Disillusion" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 4b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="The watcher wails in agony as the shadow-wreath around its form is pulled away, exposing its true form. You and the members of the Lodge surround the shattered soul to prevent it from escaping. (→ R1)" />
+      </alternate>
+    </card>
+    <card id="624f440a-ecc7-47ff-9e67-8d9e33e938a0" name="The Broken Rite" size="HorizCard">
+      <property name="Card Number" value="248" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Act 4a" />
+      <property name="Type" value="Act" />
+      <property name="Text" value="θ During a circle action, spend 1 clue: Reduce the difficulty of this skill test by 2.Objective – If The Spectral Watcher is defeated at The Geist-Trap while the brazier there is unlit, advance." />
+      <alternate name="Union" size="HorizCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Act 4b" />
+        <property name="Type" value="Act" />
+        <property name="Text" value="As the blue flame of the brazier is snuffed out, the energy around the circle disperses. (→ R4)" />
+      </alternate>
+    </card>
+    <card id="8c5e3281-80a0-41f0-9d38-7f988383ad80" name="Miskatonic River" size="EncounterCard">
+      <property name="Card Number" value="249" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="River." />
+      <alternate name="Miskatonic River" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="River." />
+        <property name="Text" value="η: Resign. You take your rowboat back to the shore of the Miskatonic River, leaving the mysterious island behind." />
+        <property name="Shroud" value="5" />
+        <property name="Clues" value="0" />
+      </alternate>
+    </card>
+    <card id="301ef491-7012-41b0-8c48-d8747541cb4a" name="Forbidding Shore" size="EncounterCard">
+      <property name="Card Number" value="250" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods." />
+      <alternate name="Forbidding Shore" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Woods." />
+        <property name="Text" value="η: Circle. Test [ά] or [έ] (3) to find the brazier by the wooded trail. If you succeed, you may light or unlight the brazier.Haunted – You must either lose 1 action or lose 2 resources." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="1π" />
+      </alternate>
+    </card>
+    <card id="d4c52940-3935-4434-b9ef-42085bb8972b" name="Unvisited Isle" size="EncounterCard">
+      <property name="Card Number" value="251" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods." />
+      <property name="Text" value="Spectral mist blocks the way. Check Campaign Log.—If the investigators sided with the Lodge, you cannot enter this location unless the brazier at the Forbidding Shore is lit.—If the investigators sided with the coven, you cannot enter this location unless the brazier at the Forbidding Shore is unlit." />
+      <property name="Victory Points" value="1" />
+      <alternate name="Unvisited Isle" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Standing Stones" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Woods." />
+        <property name="Text" value="η: Circle. Test [ά]+[έ] (10) to examine the brazier in front of the standing stone. If you succeed, you may light or unlight the brazier.Haunted – Until the end of the round, increase the difficulty of each skill test during a circle action by 2." />
+        <property name="Shroud" value="3" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="d5f6facc-cbb7-4043-9bc9-206a894d9570" name="Unvisited Isle" size="EncounterCard">
+      <property name="Card Number" value="252" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods." />
+      <property name="Text" value="Spectral mist blocks the way. Check Campaign Log.—If the investigators sided with the Lodge, you cannot enter this location unless the brazier at the Forbidding Shore is lit.—If the investigators sided with the coven, you cannot enter this location unless the brazier at the Forbidding Shore is unlit." />
+      <property name="Victory Points" value="1" />
+      <alternate name="Unvisited Isle" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Misty Clearing" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Woods." />
+        <property name="Text" value="η: Circle. Test [ά]+[ί] (11) to traverse the mist surrounding the brazier. If you succeed, you may light or unlight the brazier.Haunted – You must either place 1 doom on this location, or take 1 damage and 1 horror." />
+        <property name="Shroud" value="1" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="9863cb4c-7c67-4840-8136-7361dd98069e" name="Unvisited Isle" size="EncounterCard">
+      <property name="Card Number" value="253" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods." />
+      <property name="Text" value="Spectral mist blocks the way. Check Campaign Log.—If the investigators sided with the Lodge, you cannot enter this location unless the brazier at the Forbidding Shore is lit.—If the investigators sided with the coven, you cannot enter this location unless the brazier at the Forbidding Shore is unlit." />
+      <property name="Victory Points" value="1" />
+      <alternate name="Unvisited Isle" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Forsaken Woods" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Woods." />
+        <property name="Text" value="η: Circle. Test [ά]+[ή] (11) to clear a path through the woods. If you succeed, you may light or unlight the brazier.Haunted – You must either search the encounter deck and discard pile for a Whippoorwill and spawn it at this location, or the nearest Whippoorwill attacks you." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="5811057e-efb5-49c1-9219-8c4175f747ef" name="Unvisited Isle" size="EncounterCard">
+      <property name="Card Number" value="254" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods." />
+      <property name="Text" value="Spectral mist blocks the way. Check Campaign Log.—If the investigators sided with the Lodge, you cannot enter this location unless the brazier at the Forbidding Shore is lit.—If the investigators sided with the coven, you cannot enter this location unless the brazier at the Forbidding Shore is unlit." />
+      <property name="Victory Points" value="1" />
+      <alternate name="Unvisited Isle" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Moss-Covered Steps" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Woods." />
+        <property name="Text" value="η: Circle. Test [ή]+[ί] (10) to explore the mossy steps. If you succeed, you may light or unlight the brazier at the top.Haunted – Your next move action this round costs 1 additional action." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="0d528e4a-be44-4fb3-b1ac-a85b0c78be19" name="Unvisited Isle" size="EncounterCard">
+      <property name="Card Number" value="255" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods." />
+      <property name="Text" value="Spectral mist blocks the way. Check Campaign Log.—If the investigators sided with the Lodge, you cannot enter this location unless the brazier at the Forbidding Shore is lit.—If the investigators sided with the coven, you cannot enter this location unless the brazier at the Forbidding Shore is unlit." />
+      <property name="Victory Points" value="1" />
+      <alternate name="Unvisited Isle" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Haunted Spring" />
+        <property name="Type" value="Location" />
+        <property name="Traits" value="Woods." />
+        <property name="Text" value="η: Circle. Test [έ]+[ί] (9) to reach the brazier in the center of the spring. If you succeed, you may light or unlight the brazier.Haunted – You must either discard an asset you control, or take 1 damage." />
+        <property name="Shroud" value="2" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="366502f7-2985-49ad-a6a2-495afb3a390b" name="Unvisited Isle" size="EncounterCard">
+      <property name="Card Number" value="256" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods." />
+      <property name="Text" value="Spectral mist blocks the way. Check Campaign Log.—If the investigators sided with the Lodge, you cannot enter this location unless the brazier at the Forbidding Shore is lit.—If the investigators sided with the coven, you cannot enter this location unless the brazier at the Forbidding Shore is unlit." />
+      <property name="Victory Points" value="1" />
+      <alternate name="Unvisited Isle" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Decayed Willow" />
+        <property name="Type" value="Locatoin" />
+        <property name="Traits" value="Woods." />
+        <property name="Text" value="η: Circle. Test [έ]+[ή] (9) to find the brazier inside the decaying tree. If you succeed, you may light or unlight the brazier.Haunted – Choose and discard 1 card from your hand." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="2π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="2cf802b6-d0e0-4bb1-965a-2b61ef455515" name="The Geist-Trap" size="EncounterCard">
+      <property name="Card Number" value="257" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Location" />
+      <property name="Traits" value="Woods. Spectral." />
+      <property name="Text" value="The path leading to the site of the ritual is hidden by the spectral mist. You cannot enter The Geist-Trap." />
+      <property name="Victory Points" value="1" />
+      <alternate name="The Geist-Trap" size="EncounterCard" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Type" value="Lcoation" />
+        <property name="Traits" value="Woods. Spectral." />
+        <property name="Text" value="While The Spectral Watcher is at The Geist-Trap, it gains retaliate.η: Circle. Test [ά]+[έ]+[ή]+[ί] (20) to complete the ritual, or to disrupt it. If you succeed, you may either light or unlight the brazier here.Haunted – Take 1 damage and 1 horror." />
+        <property name="Shroud" value="4" />
+        <property name="Clues" value="1π" />
+        <property name="Victory Points" value="1" />
+      </alternate>
+    </card>
+    <card id="c734e8ac-f666-4427-8bb8-59442a47ad50" name="Gavriella Mizrah">
+      <property name="Card Number" value="258" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Not Going Down That Easily" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Veteran." />
+      <property name="Text" value="You get +1 [ή].ι After an enemy attacks you, even if that attack was canceled, exhaust Gavriella Mizrah: Discover 1 clue at your location." />
+      <property name="Health" value="4" />
+      <property name="Sanity" value="1" />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="1" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="ήΰ" />
+    </card>
+    <card id="5303ae39-304b-40d4-a513-a669bcec20aa" name="Jerome Davids">
+      <property name="Card Number" value="259" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="In Way Over His Head" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Assistant." />
+      <property name="Text" value="You get +1 [έ].ι When an investigator at your location draws a treachery from the encounter deck, exhaust Jerome Davids and discard cards from your hand with a total of at least 2 [έ] icons: Cancel that card's revelation effect." />
+      <property name="Health" value="1" />
+      <property name="Sanity" value="4" />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="1" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="έΰ" />
+    </card>
+    <card id="7acf3471-3b4d-4ee4-baba-0b51229a1f13" name="Penny White">
+      <property name="Card Number" value="260" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="The Nightmare Is Over" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Assistant." />
+      <property name="Text" value="You get +1 [ά].ι After you succeed at a skill test during a revelation effect, exhaust Penny White: Discover 1 clue at your location." />
+      <property name="Health" value="3" />
+      <property name="Sanity" value="2" />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="1" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="0" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="άΰ" />
+    </card>
+    <card id="b065e1a1-9612-45e3-a4e8-65105751b892" name="Valentino Rivas">
+      <property name="Card Number" value="261" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Subtitle" value="Took You Long Enough" />
+      <property name="Type" value="Asset" />
+      <property name="Traits" value="Ally. Socialite." />
+      <property name="Text" value="You get +1 [ί].θ During a skill test you are performing, spend 2 resources and exhaust Valentino Rivas: Reduce the difficulty of this test by 1." />
+      <property name="Health" value="2" />
+      <property name="Sanity" value="3" />
+      <property name="Class" value="Neutral" />
+      <property name="Level" value="0" />
+      <property name="Cost" value="2" />
+      <property name="Willpower" value="0" />
+      <property name="Intellect" value="0" />
+      <property name="Combat" value="0" />
+      <property name="Agility" value="1" />
+      <property name="Slot" value="Ally" />
+      <property name="Skill Icons" value="ίΰ" />
+    </card>
+    <card id="e89cab8c-6f2f-40b2-aec4-ac7bd1462c6c" name="Gavriella’s Fate">
+      <property name="Card Number" value="262" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Story" />
+      <property name="Text" value="Check the “Missing Persons” section of the Campaign Log. If Gavriella disappeared into the mist and you are on Gavriella’s trail:Gavriella stumbles out of the mist, her eyes bloodshot and her voice strained. “Where am I?... Who are you?”Take control of the set-aside Gavriella Mizrah asset. For the remainder of this scenario, she does not take up an ally slot. Next to Gavriella Mizrah’s profile, record Gavriella is alive.If Gavriella was claimed by specters:Flip this card to its enemy side and spawn it at your location. If you are on Gavriella’s trail, it spawns exhausted and unengaged. Otherwise, it spawns engaged with you.Otherwise:You find Gavriella’s weapon lying in the grass, decayed and broken. No other sign of her can be seen." />
+      <property name="Victory Points" value="0" />
+      <alternate name="Gavriella Mizrah" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="You're Next" />
+        <property name="Type" value="Enemy" />
+        <property name="Traits" value="Humanoid. Geist. Sprectal. Elite." />
+        <property name="Text" value="Alert. Hunter.Forced – After you successfully attack Gavriella Mizrah, if she is ready: Take 1 horror." />
+        <property name="Health" value="4" />
+        <property name="Combat" value="5" />
+        <property name="Agility" value="2" />
+        <property name="Damage" value="2" />
+        <property name="Victory Points" value="0" />
+      </alternate>
+    </card>
+    <card id="caf24cd0-edec-48b7-b767-ef6f1af97b99" name="Jerome’s Fate">
+      <property name="Card Number" value="263" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Story" />
+      <property name="Text" value="Check the “Missing Persons” section of the Campaign Log. If Jerome disappeared into the mist and you are on Jerome’s trail:Jerome crawls out of the mist, and you help him to his feet. “My god... the mist...” he whispers. “It’s all connected... It’s all connected...”Take control of the set-aside Jerome Davids asset. For the remainder of this scenario, she does not take up an ally slot. Next to Jerome Davids’s profile, record Jerome is alive.If Jerome was claimed by specters:Flip this card to its enemy side and spawn it at your location. If you are on Jerome’s trail, it spawns exhausted and unengaged. Otherwise, it spawns engaged with you.Otherwise:You find a scrap of paper from Jerome’s pocket notebook on the ground. It simply reads: “HELP”" />
+      <property name="Victory Points" value="0" />
+      <alternate name="Jerome Davids" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Starved For Answers" />
+        <property name="Type" value="Enemy" />
+        <property name="Traits" value="Humanoid. Geist. Sprectal. Elite." />
+        <property name="Text" value="Hunter.Forced – After Jerome Davids engages you: Choose and discard 2 cards from your hand." />
+        <property name="Health" value="4" />
+        <property name="Combat" value="4" />
+        <property name="Agility" value="4" />
+        <property name="Damage" value="1" />
+        <property name="Horror" value="1" />
+        <property name="Victory Points" value="0" />
+      </alternate>
+    </card>
+    <card id="70d9976e-4cdd-4d39-a298-482d315be13f" name="Penny’s Fate">
+      <property name="Card Number" value="264" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Story" />
+      <property name="Text" value="Check the “Missing Persons” section of the Campaign Log. If Penny disappeared into the mist and you are on her trail:Penny nearly runs directly into you. Her whole body shakes with panic as you hold her safe. “A–are you alive?” she cries. “Is this nightmare finally over?”Take control of the set-aside Penny White asset. For the remainder of this scenario, she does not take up an ally slot. Next to Penny White’s profile, record Penny is alive.If Penny was claimed by specters:Flip this card to its enemy side and spawn it at your location. If you are on Penny’s trail, it spawns exhausted and unengaged. Otherwise, it spawns engaged with you.Otherwise:You find Penny’s apron lying on the ground, covered in blood. There is no other sign of her." />
+      <property name="Victory Points" value="0" />
+      <alternate name="Penny White" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Tragic Loss" />
+        <property name="Type" value="Enemy" />
+        <property name="Traits" value="Humanoid. Geist. Sprectal. Elite." />
+        <property name="Text" value="Hunter.Forced – After you successfully evade Penny White: Take 1 damage." />
+        <property name="Health" value="5" />
+        <property name="Combat" value="4" />
+        <property name="Agility" value="3" />
+        <property name="Horror" value="2" />
+        <property name="Victory Points" value="0" />
+      </alternate>
+    </card>
+    <card id="4270635a-1270-4d7e-a83f-f76e00becc10" name="Valentino’s Fate">
+      <property name="Card Number" value="265" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Story" />
+      <property name="Text" value="Check the “Missing Persons” section of the Campaign Log. If Valentino disappeared into the mist and you are on Valentino’s trail:Valentino limps out of the mist, leaning on a nearby tree. He chuckles morbidly as he spots you. “Cavalry’s finally here, eh?”Take control of the set-aside Valentino Rivas asset. For the remainder of this scenario, he does not take up an ally slot. Next to Valentino Rivas’s profile, record Valentino is alive.If Valentino was claimed by specters:Flip this card to its enemy side and spawn it at your location. If you are on Valentino’s trail, it spawns exhausted and unengaged. Otherwise, it spawns engaged with you.Otherwise:Valentino’s cane lies in the mud, cracked nearly in half. Its handle is stained with old blood." />
+      <property name="Victory Points" value="0" />
+      <alternate name="Valentino Rivas" type="B">
+        <property name="Encounter Set" value="Union and Disillusion" />
+        <property name="Subtitle" value="Ripped Asunder" />
+        <property name="Type" value="Enemy" />
+        <property name="Traits" value="Humanoid. Geist. Sprectal. Elite." />
+        <property name="Text" value="Hunter. Retaliate.Forced – After Valentino Rivas engages you: Lose 2 resources." />
+        <property name="Health" value="5" />
+        <property name="Combat" value="3" />
+        <property name="Agility" value="4" />
+        <property name="Damage" value="1" />
+        <property name="Horror" value="1" />
+        <property name="Victory Points" value="0" />
+      </alternate>
+    </card>
+    <card id="626b2e7c-3dee-4522-b7bf-f5ac7c6bacab" name="Whippoorwill" size="EncounterCard">
+      <property name="Card Number" value="266" />
+      <property name="Quantity" value="3" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Creature." />
+      <property name="Text" value="Aloof. Hunter.Each investigator at Whippoorwill’s location gets –1 [ά], –1 [έ], –1 [ή], and –1 [ί]." />
+      <property name="Health" value="1" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="4" />
+      <property name="Damage" value="0" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="13df574f-7ccd-470b-898c-5c50db2e60eb" name="Spectral Raven" size="EncounterCard">
+      <property name="Card Number" value="267" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Enemy" />
+      <property name="Traits" value="Creature. Spectral." />
+      <property name="Text" value="Prey – Lowest [έ].Alert. Hunter. Retaliate.Forced – After Spectral Raven engages you: You must either resolve each haunted ability on your location, or Spectral Raven gets +2 fight and +2 evade until the end of the investigation phase." />
+      <property name="Health" value="2" />
+      <property name="Combat" value="2" />
+      <property name="Agility" value="2" />
+      <property name="Damage" value="1" />
+      <property name="Horror" value="1" />
+    </card>
+    <card id="260173d9-6c32-4a75-8844-eca23ffcec2b" name="Eager for Death" size="EncounterCard">
+      <property name="Card Number" value="268" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Omen." />
+      <property name="Text" value="Revelation – Test [ά] (2). Increase this skill test’s difficulty by 1 for each damage on you. If you fail, take 2 horror." />
+    </card>
+    <card id="2c683365-691b-41f5-964a-65f41cd8314b" name="Psychopomp’s Song" size="EncounterCard">
+      <property name="Card Number" value="269" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Omen." />
+      <property name="Text" value="Surge. Peril.Revelation – Add Psychopomp’s Song to any investigator’s threat area.Forced – When you would take 1 or more damage: Take 2 additional damage and discard Psychopomp’s Song." />
+    </card>
+    <card id="0e75ebaa-4ace-49df-ab40-8c629d920efe" name="Death Approaches" size="EncounterCard">
+      <property name="Card Number" value="270" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Terror." />
+      <property name="Text" value="Surge. Peril.Revelation – Add Death Approaches to any investigator’s threat area.Forced – When you would take 1 or more horror: Take 2 additional horror and discard Death Approaches." />
+    </card>
+    <card id="4600ec24-0ac5-412b-a50e-dc0618a76276" name="Marked for Death" size="EncounterCard">
+      <property name="Card Number" value="271" />
+      <property name="Quantity" value="2" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse." />
+      <property name="Text" value="Revelation – Test [ί] (2). Increase this skill test’s difficulty by 1 for each horror on you. If you fail, take 2 damage." />
+    </card>
+    <card id="0932a14c-516b-40b2-a5ed-c3096388ac35" name="Watcher’s Gaze" size="EncounterCard">
+      <property name="Card Number" value="272" />
+      <property name="Quantity" value="1" />
+      <property name="Encounter Set" value="Union and Disillusion" />
+      <property name="Type" value="Treachery" />
+      <property name="Traits" value="Curse." />
+      <property name="Text" value="Revelation – Each investigator tests [ά] (5). Each investigator who fails must resolve either the haunted ability on his or her location, or the haunted ability on The Spectral Watcher’s location." />
+    </card>
+  </cards>
+</set>


### PR DESCRIPTION
1. Add set and deck files for Guardians of the Abyss and the rest of TCU.
2. Update TCU prologue investigator decks to have all cards in main deck. Before this, some cards were in 2nd deck, which is not obvious to everyone.
3. Multiclass cards from The Secret Name are put as Neutral at the moment.

Great thanks to Ben#9270 for providing set & deck files. I only make some (minor) adjustments and create this pull request. Also thanks to rushl#0214 for teaching me how to do this properly!!