### PR TITLE
Chaos Token shenanigans

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1604,7 +1604,16 @@ def drawAddChaosToken(player, group, x = 0, y = 0):
     else:
         remoteCall(chaosBag().controller, "drawChaosTokenForPlayer", [me,  chaosBag(), x, y, False, num*10, num*10])
 
-def sealToken(player, group, x = 0, y = 0):
+def sealToken(group, x = 0, y = 0, player = None):
+    mute()
+
+    if chaosBag().controller != me:
+        remoteCall(chaosBag().controller, "sealToken", [group, x, y, me])
+        return
+
+    if player == None:
+        player = me
+
     list = [card for card in table
                 if (card.Type == 'Chaos Token') and (card.Subtype != 'Sealed')]
     for card in chaosBag():
@@ -1612,10 +1621,15 @@ def sealToken(player, group, x = 0, y = 0):
     dlg = cardDlg(list)
     dlg.title = "Seal Chaos Token"
     dlg.text = "Select a Chaos Token to seal"
-    card = dlg.show()[0]
+    card = dlg.show()
+    if card == None:
+        return
+    card = card[0]
     card.moveToTable(ChaosTokenX, ChaosTokenY)
     card.Subtype = 'Sealed'
     card.filter = "#99999999"
+    card.controller = player
+    notify("{} seals {}.".format(player, card.name))
 
 def drawBasicWeakness(group, x = 0, y = 0):
     mute()

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1615,6 +1615,7 @@ def sealToken(player, group, x = 0, y = 0):
     card = dlg.show()[0]
     card.moveToTable(ChaosTokenX, ChaosTokenY)
     card.Subtype = 'Sealed'
+    card.filter = "#99999999"
 
 def drawBasicWeakness(group, x = 0, y = 0):
     mute()

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1299,6 +1299,8 @@ def discardSpecial(card, x=0, y=0):
 
 def doDiscard(player, card, pile):
     mute()
+    if (card.Subtype == "Sealed") and (pile == chaosBag()):
+        card.Subtype = ""
     card.moveTo(pile)
 
 def shuffleIntoDeck(card, x=0, y=0, player=me):
@@ -1560,7 +1562,7 @@ def drawChaosTokenForPlayer(player, group, x = 0, y = 0, replace = True, xMod = 
         if replace:
             # check for existing chaos token on table
             table_chaos_tokens = [card for card in table
-                if card.Type == 'Chaos Token']
+                if (card.Type == 'Chaos Token') and (card.Subtype != 'Sealed')]
             for token in table_chaos_tokens:
                 if token.controller == me:
                     token.moveTo(chaosBag())
@@ -1602,8 +1604,17 @@ def drawAddChaosToken(player, group, x = 0, y = 0):
     else:
         remoteCall(chaosBag().controller, "drawChaosTokenForPlayer", [me,  chaosBag(), x, y, False, num*10, num*10])
 
-def sealChaosToken(player, group, x = 0, y = 0):
-    pass
+def sealToken(player, group, x = 0, y = 0):
+    list = [card for card in table
+                if (card.Type == 'Chaos Token') and (card.Subtype != 'Sealed')]
+    for card in chaosBag():
+        list.append(card)
+    dlg = cardDlg(list)
+    dlg.title = "Seal Chaos Token"
+    dlg.text = "Select a Chaos Token to seal"
+    card = dlg.show()[0]
+    card.moveToTable(ChaosTokenX, ChaosTokenY)
+    card.Subtype = 'Sealed'
 
 def drawBasicWeakness(group, x = 0, y = 0):
     mute()

--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1590,6 +1590,20 @@ def drawXChaosTokens(player, group, x = 0, y = 0):
         else:
             remoteCall(chaosBag().controller, "drawChaosTokenForPlayer", [me,  chaosBag(), x, y, replace, (xTokens * 10), (xTokens * 10)])
 
+def drawAddChaosToken(player, group, x = 0, y = 0):
+    mute()
+    num = 0
+    for card in table: #find out how many Tokens there already are
+        if card.Type == "Chaos Token":
+            num += 1
+
+    if chaosBag().controller == me:
+        drawChaosTokenForPlayer(me, chaosBag(), x, y, False, num*10, num*10)
+    else:
+        remoteCall(chaosBag().controller, "drawChaosTokenForPlayer", [me,  chaosBag(), x, y, False, num*10, num*10])
+
+def sealChaosToken(player, group, x = 0, y = 0):
+    pass
 
 def drawBasicWeakness(group, x = 0, y = 0):
     mute()

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -116,6 +116,8 @@
 		<groupaction menu="Hidden Encounter Card (Special Deck)" default="False" shortcut="ctrl+shift+H" execute="addHiddenSpecial" />
 		<groupaction menu="Draw Token from ChaosBag" default="False" shortcut="ctrl+S" execute="drawChaosToken" />
 		<groupaction menu="Draw X Tokens from ChaosBag" default="False" shortcut="" execute="drawXChaosTokens" />
+		<groupaction menu="Draw additional Token from ChaosBag" default="False" shortcut="" execute="drawAddChaosToken" />
+		<groupaction menu="Seal Token from Chaosbag" default="False" shortcut="" execute="sealToken" />
 		
 		<groupaction menu="Ready to Refresh" default="False" shortcut="ctrl+R" execute="readyForRefresh" />
 		<groupaction menu="Ready for next round" default="False" shortcut="ctrl+N" execute="readyForNextRound" />


### PR DESCRIPTION
I added the ability to draw additional tokens, without putting the old ones back into the Bag.
Furthermore I implemented the Seal Mechanic. For this I am utilizing the Subtype property of the Chaos Tokens, since I doubt this will ever be used otherwise. Chaos Tokens with the Subtype "Sealed" will not be automatically removed from the Table. If the Token is discarded, the property is automatically removed again.
Sealed Tokens are currently displayed with a slight grey-filter, since I didn't think of any other way to easily mark them as sealed.

While I did test it with two clients to make sure it also works in Multiplayer, I would like someone else to take a look at it, just in case I missed something. Also I am open for suggestions.