### PR TITLE
Card-Context menu entry to seal Chaostoken directly and Bugfixes

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1549,6 +1549,9 @@ def drawPileToTable(player, group, x, y):
 
     card = group[0]
     card.moveToTable(x, y)
+    #failsave for sealed attribute
+    if card.Type == "Chaos Token" and card.Subtype == "Sealed":
+        card.Subtype = ""
     notify("{} draws {} from the {}.".format(player, card.name, group.name))
     return card
     
@@ -1603,6 +1606,23 @@ def drawAddChaosToken(player, group, x = 0, y = 0):
         drawChaosTokenForPlayer(me, chaosBag(), x, y, False, num*10, num*10)
     else:
         remoteCall(chaosBag().controller, "drawChaosTokenForPlayer", [me,  chaosBag(), x, y, False, num*10, num*10])
+
+def sealTokenCard(card, x = 0, y = 0, player = None):
+    if card.controller != me:
+        remoteCall(card.controller, "sealTokenCard", [card, x, y, me])
+        return
+
+    if player == None:
+        player = me
+
+    #failsave
+    if card == None:
+        return
+
+    card.Subtype = 'Sealed'
+    card.filter = "#99999999"
+    card.controller = player
+    notify("{} seals {}.".format(player, card.name))
 
 def sealToken(group, x = 0, y = 0, player = None):
     mute()

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -5,7 +5,7 @@
 	id="a6d114c7-2e2a-4896-ad8c-0330605c90bf" 
 	octgnVersion="3.1.162.361"
 	scriptVersion ="3.1.0.2"
-	version="1.6.4.0"
+	version="1.6.4.1"
 	markersize="16"
 	tags="AH LCG cooperative"
 	description="Arkham Horror: The Card Game is a cooperative Living Card Game® set amid a backdrop of Lovecraftian horror. As the Ancient Ones seek entry to our world, one to four investigators work to unravel arcane mysteries and conspiracies.&#10;&#10;Their efforts determine not only the course of your game, but carry forward throughout whole campaigns, challenging them to overcome their personal demons even as Arkham Horror: The Card Game blurs the distinction between the card game and roleplaying experiences."
@@ -163,6 +163,7 @@
 		<cardaction menu="Rotate Left" default="False" shortcut="F8" execute="rotateLeft" />
 		<cardaction menu="Rotate Right" default="False" shortcut="F9" execute="rotateRight" />
 		<cardaction menu="Double Click" default="True" execute="defaultAction" />
+		<cardaction menu="Seal Token" defalault="False" execute="sealTokenCard" />
 		<groupactions menu="Path Markers">
 			<groupaction menu="Orthagonal on front side. Flip for diagonal." default="False" execute="" />
 			<groupseparator />


### PR DESCRIPTION
 - Fix for the Token keeping the Sealed-Attribute after being moved to the Chaosbag instead of being discarded
 - added the possibility to seal a drawn Token by right-clicking it
 - bumped the Buildnumber in case the fixes will be deployed before the next pack releases.

(Thanks to Ken for the recommendations)