### PR TITLE
Fix laodTable trying to open file on cancelation

### DIFF
--- a/o8g/Scripts/plugin.py
+++ b/o8g/Scripts/plugin.py
@@ -120,6 +120,8 @@ def loadTable(phase):
 				phase = n.readline()
 				notify("Restore Table state saves to last {} phase".format(phase))
 
+		if not filename:
+			return
 
 		with open(filename, 'r') as f:
 			tab = json().DeserializeObject(f.read())


### PR DESCRIPTION
Stop loadTable from trying to open file when user closed or canceled dialog box.