### PR TITLE
Consistency and typo fixes

### DIFF
--- a/o8g/Decks/01 - Night of the Zealot/2 - The Midnight Masks.o8d
+++ b/o8g/Decks/01 - Night of the Zealot/2 - The Midnight Masks.o8d
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
   <section name="Agenda" shared="True">
-    <card qty="1" id="d533f5ae-53fc-4bbb-96b9-d0f26364c387">Predator or Prey</card>
-    <card qty="1" id="193ea5c4-b871-4b10-9672-dde886264264">Time is Running Short</card>
+    <card qty="1" id="d533f5ae-53fc-4bbb-96b9-d0f26364c387">Predator or Prey?</card>
+    <card qty="1" id="193ea5c4-b871-4b10-9672-dde886264264">Time Is Running Short</card>
   </section>
   <section name="Act" shared="True">
     <card qty="1" id="bc8fc57c-2629-40c0-9da3-634e0dbc4d7c">Uncovering the Conspiracy</card>
@@ -19,7 +19,7 @@
     <card qty="2" id="dc0e7a80-2902-4760-8eeb-2ddb6fe8ee93">Locked Door</card>
   </section>
   <section name="Special" shared="True">
-    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">Wolf-man Drew</card>
+    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">"Wolf-Man" Drew</card>
     <card qty="1" id="8ebd7f12-7dfd-46fa-9df9-5a869e752740">Herman Collins</card>
     <card qty="1" id="2dc5134a-a78c-4063-bcca-be24ee436798">Peter Warren</card>
     <card qty="1" id="2eabec3d-6cc1-4b54-8fd0-f4640da8986b">Victoria Devereux</card>
@@ -38,7 +38,7 @@
     <card qty="1" id="945f53f9-9302-4010-812d-c7b717b2a81d">Miskatonic University</card>
     <card qty="1" id="eb341e79-1eb1-46f9-9d25-eff09fe096c9">Downtown</card>
     <card qty="1" id="b66282e2-c327-4e19-9348-3a720cc165e4">Downtown</card>
-    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">East Town</card>
+    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">Easttown</card>
     <card qty="1" id="45640790-e6ac-47e2-ab27-73f030fc3e9c">Graveyard</card>
     <card qty="1" id="8fc61c54-6c1b-4109-9f64-6cd6bc0f4c50">Northside</card>
     <card qty="3" id="8d7edcd9-63e0-4d2f-b8a1-c1e7cbf11c7a">Acolyte</card>

--- a/o8g/Decks/01 - Night of the Zealot/3 - The Devourer Below.o8d
+++ b/o8g/Decks/01 - Night of the Zealot/3 - The Devourer Below.o8d
@@ -44,14 +44,14 @@
   </section>
   <section name="Second Special" shared="True">
     <card qty="1" id="060db76e-909e-4b71-8798-a9494f29d63b">Ghoul Priest</card>
-    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">Wolf-man Drew</card>
+    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">"Wolf-Man" Drew</card>
     <card qty="1" id="8ebd7f12-7dfd-46fa-9df9-5a869e752740">Herman Collins</card>
     <card qty="1" id="2dc5134a-a78c-4063-bcca-be24ee436798">Peter Warren</card>
     <card qty="1" id="2eabec3d-6cc1-4b54-8fd0-f4640da8986b">Victoria Devereux</card>
     <card qty="1" id="fc6b957f-5e19-46a7-b742-029f8f9fa5b5">Ruth Turner</card>
     <card qty="1" id="d533f5ae-53fc-4bbb-96b9-d0f26364c387">Predator or Prey</card>
     <card qty="1" id="96ae3844-8204-4f49-bf21-3fe67a03df98">Ritual Site</card>
-    <card qty="1" id="2b4c8caa-4e83-444e-b73d-bee8a0a96063">Umordhoth</card>
+    <card qty="1" id="2b4c8caa-4e83-444e-b73d-bee8a0a96063">Umôrdhoth</card>
   </section>
   <section name="Chaos Bag" shared="True" />
   <section name="Setup" shared="True">

--- a/o8g/Decks/01R - Return to the Night of the Zealot/2 - Return to The Midnight Masks.o8d
+++ b/o8g/Decks/01R - Return to the Night of the Zealot/2 - Return to The Midnight Masks.o8d
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
   <section name="Agenda" shared="True">
-    <card qty="1" id="d533f5ae-53fc-4bbb-96b9-d0f26364c387">Predator or Prey</card>
+    <card qty="1" id="d533f5ae-53fc-4bbb-96b9-d0f26364c387">Predator or Prey?</card>
     <card qty="1" id="88bddeac-9738-45c5-b8d1-a80aa0526af3">Predator or Prey?</card>
-    <card qty="1" id="193ea5c4-b871-4b10-9672-dde886264264">Time is Running Short</card>
+    <card qty="1" id="193ea5c4-b871-4b10-9672-dde886264264">Time Is Running Short</card>
   </section>
   <section name="Act" shared="True">
     <card qty="1" id="bc8fc57c-2629-40c0-9da3-634e0dbc4d7c">Uncovering the Conspiracy</card>
@@ -21,7 +21,7 @@
     <card qty="2" id="11c05026-4172-4726-9912-aa3f38826335">Masked Horrors</card>
   </section>
   <section name="Special" shared="True">
-    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">Wolf-man Drew</card>
+    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">"Wolf-Man" Drew</card>
     <card qty="1" id="8ebd7f12-7dfd-46fa-9df9-5a869e752740">Herman Collins</card>
     <card qty="1" id="2dc5134a-a78c-4063-bcca-be24ee436798">Peter Warren</card>
     <card qty="1" id="2eabec3d-6cc1-4b54-8fd0-f4640da8986b">Victoria Devereux</card>
@@ -46,7 +46,7 @@
     <card qty="1" id="fdf83f91-9221-4969-86f8-7a00f2db4c57">Miskatonic University</card>
     <card qty="1" id="eb341e79-1eb1-46f9-9d25-eff09fe096c9">Downtown</card>
     <card qty="1" id="b66282e2-c327-4e19-9348-3a720cc165e4">Downtown</card>
-    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">East Town</card>
+    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">Easttown</card>
     <card qty="1" id="044fef90-d736-4096-bdd9-9690686cc3fc">Easttown</card>
     <card qty="1" id="45640790-e6ac-47e2-ab27-73f030fc3e9c">Graveyard</card>
     <card qty="1" id="8fc61c54-6c1b-4109-9f64-6cd6bc0f4c50">Northside</card>

--- a/o8g/Decks/01R - Return to the Night of the Zealot/3 - Return to The Devourer Below.o8d
+++ b/o8g/Decks/01R - Return to the Night of the Zealot/3 - Return to The Devourer Below.o8d
@@ -38,7 +38,7 @@
   <section name="Second Special" shared="True">
     <card qty="1" id="060db76e-909e-4b71-8798-a9494f29d63b">Ghoul Priest</card>
     <card qty="1" id="d533f5ae-53fc-4bbb-96b9-d0f26364c387">Predator or Prey</card>
-    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">Wolf-man Drew</card>
+    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">"Wolf-Man" Drew</card>
     <card qty="1" id="8ebd7f12-7dfd-46fa-9df9-5a869e752740">Herman Collins</card>
     <card qty="1" id="2dc5134a-a78c-4063-bcca-be24ee436798">Peter Warren</card>
     <card qty="1" id="2eabec3d-6cc1-4b54-8fd0-f4640da8986b">Victoria Devereux</card>
@@ -48,7 +48,7 @@
     <card qty="1" id="9a76a809-4675-40bf-b161-423a3c5dcc82">Billy Cooper</card>
     <card qty="1" id="386b3309-1666-4955-933f-0f011b7174a8">Alma Hill</card>
     <card qty="1" id="96ae3844-8204-4f49-bf21-3fe67a03df98">Ritual Site</card>
-    <card qty="1" id="2b4c8caa-4e83-444e-b73d-bee8a0a96063">Umordhoth</card>
+    <card qty="1" id="2b4c8caa-4e83-444e-b73d-bee8a0a96063">Umôrdhoth</card>
   </section>
   <section name="Setup" shared="True">
     <card qty="1" id="0db17bb7-4da6-4118-95a1-aca37aba251c">The Devourer Below</card>

--- a/o8g/Decks/02 - The Dunwich Legacy/4 - Blood on the Altar.o8d
+++ b/o8g/Decks/02 - The Dunwich Legacy/4 - Blood on the Altar.o8d
@@ -9,7 +9,7 @@
   <section name="Sideboard" shared="False" />
   <section name="Basic Weaknesses" shared="False" />
   <section name="Agenda" shared="True">
-    <card qty="1" id="a8ba171e-ce59-42fb-90d0-8a08132ae2fc">Strange Disapperances</card>
+    <card qty="1" id="a8ba171e-ce59-42fb-90d0-8a08132ae2fc">Strange Disappearances</card>
     <card qty="1" id="90620ea4-d4c6-4cec-885d-33bf02ca293a">The Old Ones Hunger</card>
     <card qty="1" id="648fdeea-619c-4e73-b3ba-d1346a397338">Feed the Beast</card>
   </section>

--- a/o8g/Decks/02R - Return to the Dunwich Legacy/4 - Return to Blood on the Altar.o8d
+++ b/o8g/Decks/02R - Return to the Dunwich Legacy/4 - Return to Blood on the Altar.o8d
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <deck game="a6d114c7-2e2a-4896-ad8c-0330605c90bf">
   <section name="Agenda" shared="True">
-    <card qty="1" id="a8ba171e-ce59-42fb-90d0-8a08132ae2fc">Strange Disapperances</card>
+    <card qty="1" id="a8ba171e-ce59-42fb-90d0-8a08132ae2fc">Strange Disappearances</card>
     <card qty="1" id="90620ea4-d4c6-4cec-885d-33bf02ca293a">The Old Ones Hunger</card>
     <card qty="1" id="648fdeea-619c-4e73-b3ba-d1346a397338">Feed the Beast</card>
   </section>

--- a/o8g/Decks/04 - The Forgotten Age/3 - Threads of Fate.o8d
+++ b/o8g/Decks/04 - The Forgotten Age/3 - Threads of Fate.o8d
@@ -69,7 +69,7 @@
     <card qty="1" id="3e01c1d4-8e5c-472b-b803-357c6474ca01">Threads of Fate</card>
     <card qty="1" id="8fc61c54-6c1b-4109-9f64-6cd6bc0f4c50">Northside</card>
     <card qty="1" id="eb341e79-1eb1-46f9-9d25-eff09fe096c9">Downtown</card>
-    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">East Town</card>
+    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">Easttown</card>
     <card qty="1" id="945f53f9-9302-4010-812d-c7b717b2a81d">Miskatonic University</card>
     <card qty="1" id="2e8e4d5e-5c7d-412b-9971-73b7b920de6d">Rivertown</card>
     <card qty="1" id="9c3d252b-4623-4e0c-b5eb-03a2a39b0186">Velma's Diner</card>

--- a/o8g/Decks/04 - The Forgotten Age/8 - Shattered Aeons.o8d
+++ b/o8g/Decks/04 - The Forgotten Age/8 - Shattered Aeons.o8d
@@ -33,7 +33,7 @@
     <card qty="1" id="2f2f179f-dbbc-4bfc-85cc-b67e1bd7aa9a">Ancient Evils</card>
   </section>
   <section name="Second Special" shared="True">
-    <card qty="1" id="74080182-a727-4a63-98b0-42e0909e4bdc">Ictaca</card>
+    <card qty="1" id="74080182-a727-4a63-98b0-42e0909e4bdc">Ichtaca</card>
     <card qty="1" id="bbe64a25-336f-4deb-a46c-6dfb3909b5dd">Alejandro Vela</card>
     <card qty="1" id="f9b9ed93-13c5-48ed-9063-4d373a57fbde">Formless Spawn</card>
     <card qty="1" id="0511e933-fe25-4020-8014-cd4c8aa23cb1">Relic of Ages</card>

--- a/o8g/Decks/04R - Return to the Forgotten Age/3 - Return to Threads of Fate.o8d
+++ b/o8g/Decks/04R - Return to the Forgotten Age/3 - Return to Threads of Fate.o8d
@@ -68,7 +68,7 @@
     <card qty="1" id="8878eefa-e958-4b1f-9801-5c4127411fcc">Return to Threads of Fate</card>
     <card qty="1" id="8fc61c54-6c1b-4109-9f64-6cd6bc0f4c50">Northside</card>
     <card qty="1" id="eb341e79-1eb1-46f9-9d25-eff09fe096c9">Downtown</card>
-    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">East Town</card>
+    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">Easttown</card>
     <card qty="1" id="945f53f9-9302-4010-812d-c7b717b2a81d">Miskatonic University</card>
     <card qty="1" id="2e8e4d5e-5c7d-412b-9971-73b7b920de6d">Rivertown</card>
     <card qty="1" id="9c3d252b-4623-4e0c-b5eb-03a2a39b0186">Velma's Diner</card>

--- a/o8g/Decks/04R - Return to the Forgotten Age/8 - Return to Shattered Aeons.o8d
+++ b/o8g/Decks/04R - Return to the Forgotten Age/8 - Return to Shattered Aeons.o8d
@@ -29,7 +29,7 @@
     <card qty="1" id="a5c8b4b4-31a3-4ca5-93c9-5ed4063f6eb2">Great Hall of Celeano</card>
   </section>
   <section name="Second Special" shared="True">
-    <card qty="1" id="74080182-a727-4a63-98b0-42e0909e4bdc">Ictaca</card>
+    <card qty="1" id="74080182-a727-4a63-98b0-42e0909e4bdc">Ichtaca</card>
     <card qty="1" id="bbe64a25-336f-4deb-a46c-6dfb3909b5dd">Alejandro Vela</card>
     <card qty="1" id="f9b9ed93-13c5-48ed-9063-4d373a57fbde">Formless Spawn</card>
     <card qty="1" id="0511e933-fe25-4020-8014-cd4c8aa23cb1">Relic of Ages</card>

--- a/o8g/Decks/05 - The Circle Undone/4 - The Wages of Sin.o8d
+++ b/o8g/Decks/05 - The Circle Undone/4 - The Wages of Sin.o8d
@@ -20,7 +20,7 @@
     <card qty="2" id="ff76e088-1395-4e10-8a43-17de4c914049">Vengeful Witch</card>
     <card qty="2" id="051bcbce-880a-4a89-a41c-48e6dc451815">Punishment</card>
     <card qty="2" id="288969bc-3df6-431e-b04d-f0d150af3be4">Ominous Portents</card>
-    <card qty="2" id="1529b14f-ab18-4db9-841a-b0b603f1efde">Grave-light</card>
+    <card qty="2" id="1529b14f-ab18-4db9-841a-b0b603f1efde">Grave-Light</card>
     <card qty="3" id="343b9330-c6b0-4ad3-90b0-aef7cab1ba12">Coven Initiate</card>
     <card qty="1" id="6348e5e1-57f3-4f44-90f0-d3593e3c43ec">Priestess of the Coven</card>
     <card qty="2" id="edbb082b-fdd8-42de-a328-fcd65398e1fc">Evil Past</card>

--- a/o8g/Decks/05R - Return to the Circle Undone/4 - Return to The Wages of Sin.o8d
+++ b/o8g/Decks/05R - Return to the Circle Undone/4 - Return to The Wages of Sin.o8d
@@ -14,7 +14,7 @@
     <card qty="2" id="ff76e088-1395-4e10-8a43-17de4c914049">Vengeful Witch</card>
     <card qty="2" id="051bcbce-880a-4a89-a41c-48e6dc451815">Punishment</card>
     <card qty="2" id="288969bc-3df6-431e-b04d-f0d150af3be4">Ominous Portents</card>
-    <card qty="2" id="1529b14f-ab18-4db9-841a-b0b603f1efde">Grave-light</card>
+    <card qty="2" id="1529b14f-ab18-4db9-841a-b0b603f1efde">Grave-Light</card>
     <card qty="3" id="343b9330-c6b0-4ad3-90b0-aef7cab1ba12">Coven Initiate</card>
     <card qty="1" id="6348e5e1-57f3-4f44-90f0-d3593e3c43ec">Priestess of the Coven</card>
     <card qty="2" id="19897337-867f-46da-88ef-d992a7ab68e2">Vice and Villainy</card>

--- a/o8g/Decks/06 - The Dream-Eaters/1B - Waking Nightmare.o8d
+++ b/o8g/Decks/06 - The Dream-Eaters/1B - Waking Nightmare.o8d
@@ -44,7 +44,7 @@
     <card qty="3" id="9f74e2e9-5c16-4c0a-ab6b-a2dd7f8b1882">Swarm of Spiders</card>
     <card qty="2" id="8387d538-c00f-471e-b560-8b6d562e1cba">Sickening Webs</card>
     <card qty="3" id="f06ea8e3-84ca-4c65-924f-623d97dc6280">Outbreak</card>
-    <card qty="1" id="4f315e5b-2958-4036-ae66-0b27d965024c">The Infestation Begins...</card>
+    <card qty="1" id="4f315e5b-2958-4036-ae66-0b27d965024c">The Infestation Begins…</card>
     <card qty="2" id="9e01fd73-3281-4345-9087-8a3831017adf">Corrupted Orderly</card>
     <card qty="2" id="c0866625-0f2d-4223-9fea-c9ad99a30e24">Grey Weaver</card>
     <card qty="2" id="731203b3-42bb-414b-b780-ca7205632611">Will of the Spider-Mother</card>

--- a/o8g/Decks/07 - The Innsmouth Conspiracy/7 - The Lair of Dagon.o8d
+++ b/o8g/Decks/07 - The Innsmouth Conspiracy/7 - The Lair of Dagon.o8d
@@ -48,7 +48,7 @@
     <card qty="2" id="d562fa63-5211-4e61-aa5c-43262f02a758">Tidal Alignment</card>
     <card qty="2" id="b58c74c7-88c8-4b1f-b1b8-96851ed1b00e">Syzygy</card>
     <card qty="1" id="3ccec31f-fe68-41df-b86d-a73b43131bb0">Y'ha-nthlei Statue</card>
-    <card qty="1" id="c004574d-7773-4569-bd7a-548a96335ce6">Apoostle of Dagon</card>
+    <card qty="1" id="c004574d-7773-4569-bd7a-548a96335ce6">Apostle of Dagon</card>
     <card qty="1" id="6b97f2cc-13a9-4add-8683-23e2ff7fb06b">Dagon</card>
     <card qty="1" id="e8d46363-6c2c-4b5b-a5f0-a383e2040b66">Robert Friendly</card>
     <card qty="1" id="d5482954-c76e-4896-aa13-d234b8abcd4c">Zadok Allen</card>

--- a/o8g/Decks/102 - Carnevale of Horrors/Carnevale of Horrors - Campaign Version.o8d
+++ b/o8g/Decks/102 - Carnevale of Horrors/Carnevale of Horrors - Campaign Version.o8d
@@ -39,12 +39,12 @@
     <card qty="1" id="0cc17a30-bd37-41a0-b8ed-c0fef10abb97">Rialto Bridge</card>
     <card qty="1" id="f9f1e203-30d8-4b7a-8062-d4135c727f65">Venetian Garden</card>
     <card qty="1" id="f1b60ac1-536c-4e98-b2ca-e71386ebab6d">Flooded Square</card>
-    <card qty="1" id="08f83237-d86e-4f23-abd7-4ff1db2873f8">Streets of Veince</card>
+    <card qty="1" id="08f83237-d86e-4f23-abd7-4ff1db2873f8">Streets of Venice</card>
     <card qty="1" id="33c71654-227f-44ac-90bf-c0550d14fb5e">Accademia Bridge</card>
     <card qty="1" id="e4b91703-d264-4aaa-93f4-878207232031">The Guardian</card>
   </section>
   <section name="Special" shared="True">
-    <card qty="1" id="4c4faf51-f697-4c74-8859-c4b5221d5897">Elisabetta Margo</card>
+    <card qty="1" id="4c4faf51-f697-4c74-8859-c4b5221d5897">Elisabetta Magro</card>
     <card qty="1" id="d970c25b-c61d-4abe-841d-442ec907b4fb">Don Lagorio</card>
     <card qty="1" id="7dd9e264-2dce-40e2-be80-44ce5285430b">Salvatore Neri</card>
     <card qty="1" id="ad4fc422-bdb7-4308-a7df-009022796002">Savio Corvi</card>

--- a/o8g/Decks/102 - Carnevale of Horrors/Carnevale of Horrors - Standalone Hard Difficulty.o8d
+++ b/o8g/Decks/102 - Carnevale of Horrors/Carnevale of Horrors - Standalone Hard Difficulty.o8d
@@ -51,7 +51,7 @@
     <card qty="1" id="ca0b7b2a-8992-483b-8094-b3c515af8967">Elder Sign</card>
   </section>
   <section name="Location" shared="True">
-    <card qty="1" id="08f83237-d86e-4f23-abd7-4ff1db2873f8">Streets of Veince</card>
+    <card qty="1" id="08f83237-d86e-4f23-abd7-4ff1db2873f8">Streets of Venice</card>
     <card qty="1" id="0cc17a30-bd37-41a0-b8ed-c0fef10abb97">Rialto Bridge</card>
     <card qty="1" id="f9f1e203-30d8-4b7a-8062-d4135c727f65">Venetian Garden</card>
     <card qty="1" id="bda65d6e-fb86-4b41-a575-595479e53ed0">Bridge of Sighs</card>
@@ -61,7 +61,7 @@
   </section>
   <section name="Special" shared="True">
     <card qty="1" id="d970c25b-c61d-4abe-841d-442ec907b4fb">Don Lagorio</card>
-    <card qty="1" id="4c4faf51-f697-4c74-8859-c4b5221d5897">Elisabetta Margo</card>
+    <card qty="1" id="4c4faf51-f697-4c74-8859-c4b5221d5897">Elisabetta Magro</card>
     <card qty="1" id="7dd9e264-2dce-40e2-be80-44ce5285430b">Salvatore Neri</card>
     <card qty="1" id="ad4fc422-bdb7-4308-a7df-009022796002">Savio Corvi</card>
     <card qty="3" id="e77f99ff-5c58-4dd8-9889-87f039493046">Innocent Reveler</card>

--- a/o8g/Decks/102 - Carnevale of Horrors/Carnevale of Horrors - Standalone Standard Difficulty.o8d
+++ b/o8g/Decks/102 - Carnevale of Horrors/Carnevale of Horrors - Standalone Standard Difficulty.o8d
@@ -50,7 +50,7 @@
     <card qty="1" id="ca0b7b2a-8992-483b-8094-b3c515af8967">Elder Sign</card>
   </section>
   <section name="Location" shared="True">
-    <card qty="1" id="08f83237-d86e-4f23-abd7-4ff1db2873f8">Streets of Veince</card>
+    <card qty="1" id="08f83237-d86e-4f23-abd7-4ff1db2873f8">Streets of Venice</card>
     <card qty="1" id="0cc17a30-bd37-41a0-b8ed-c0fef10abb97">Rialto Bridge</card>
     <card qty="1" id="f9f1e203-30d8-4b7a-8062-d4135c727f65">Venetian Garden</card>
     <card qty="1" id="bda65d6e-fb86-4b41-a575-595479e53ed0">Bridge of Sighs</card>
@@ -60,7 +60,7 @@
   </section>
   <section name="Special" shared="True">
     <card qty="1" id="d970c25b-c61d-4abe-841d-442ec907b4fb">Don Lagorio</card>
-    <card qty="1" id="4c4faf51-f697-4c74-8859-c4b5221d5897">Elisabetta Margo</card>
+    <card qty="1" id="4c4faf51-f697-4c74-8859-c4b5221d5897">Elisabetta Magro</card>
     <card qty="1" id="7dd9e264-2dce-40e2-be80-44ce5285430b">Salvatore Neri</card>
     <card qty="1" id="ad4fc422-bdb7-4308-a7df-009022796002">Savio Corvi</card>
     <card qty="3" id="e77f99ff-5c58-4dd8-9889-87f039493046">Innocent Reveler</card>

--- a/o8g/Decks/106 - The Blob That Ate Everything/Epic Multiplayer.o8d
+++ b/o8g/Decks/106 - The Blob That Ate Everything/Epic Multiplayer.o8d
@@ -15,7 +15,7 @@
   </section>
   <section name="Act" shared="True">
     <card qty="1" id="fa2ac37c-f845-4790-acbc-b12d61e6a649">Expose the Anomaly</card>
-    <card qty="1" id="87a2c12b-7f2f-4c24-8850-c508d1ec0861">Extra terrestrial Physiology</card>
+    <card qty="1" id="87a2c12b-7f2f-4c24-8850-c508d1ec0861">Extraterrestrial Physiology</card>
     <card qty="1" id="fee539c0-c753-482f-8c5f-a07534da6f45">Blackwater's Bane</card>
   </section>
   <section name="Encounter" shared="True">

--- a/o8g/Decks/106 - The Blob That Ate Everything/Single Group.o8d
+++ b/o8g/Decks/106 - The Blob That Ate Everything/Single Group.o8d
@@ -15,7 +15,7 @@
   </section>
   <section name="Act" shared="True">
     <card qty="1" id="f575a61f-83dc-447e-90b4-5a608329b4d6">Expose the Anomaly</card>
-    <card qty="1" id="87a2c12b-7f2f-4c24-8850-c508d1ec0861">Extra terrestrial Physiology</card>
+    <card qty="1" id="87a2c12b-7f2f-4c24-8850-c508d1ec0861">Extraterrestrial Physiology</card>
     <card qty="1" id="11ba3263-ffc5-4b8e-a8a6-acc55d0b2091">Blackwater's Bane</card>
   </section>
   <section name="Encounter" shared="True">

--- a/o8g/Decks/108 - War of the Outer Gods/War of the Outer Gods.o8d
+++ b/o8g/Decks/108 - War of the Outer Gods/War of the Outer Gods.o8d
@@ -16,7 +16,7 @@
     <card qty="1" id="a7344473-799d-4588-9cf2-2dc59dc0cdb5">The Summoning Progresses</card>
     <card qty="1" id="a3b8223b-751d-4a4a-a167-0b3a6197b559">The Summoning Nears Completion</card>
     <card qty="1" id="90b5f8a3-c81c-4424-89ff-a723f3a6408a">The Proliferation of the Swarm</card>
-    <card qty="1" id="d119691b-36f6-4e54-82e4-e12264b3520a">The Swarm Spreads</card>
+    <card qty="1" id="d119691b-36f6-4e54-82e4-e12264b3520a">The Proliferation Progresses</card>
     <card qty="1" id="e6495c66-75c1-461e-b3a3-a1c463476589">The Proliferation Nears Completion</card>
   </section>
   <section name="Act" shared="True">
@@ -72,7 +72,7 @@
     <card qty="1" id="695e3bdf-c738-4c79-b5b3-58d02d25f24a">Streets of Providence</card>
     <card qty="1" id="49527bd2-e98a-488a-8fcb-929c9e3eab44">Athenaeum of the Empty Sky</card>
     <card qty="1" id="94a238a0-9188-41ca-a613-be8e5ba500bc">The Arcade</card>
-    <card qty="1" id="f51c51cb-535d-4dea-9ef7-34fdebc52df8">Streets of Montreal</card>
+    <card qty="1" id="f51c51cb-535d-4dea-9ef7-34fdebc52df8">Streets of Montréal</card>
     <card qty="1" id="b83396fc-88a0-4d7b-a692-f084cf81cd7c">Chateau Ramezay</card>
     <card qty="1" id="fd0d578e-c030-48d3-a718-859fa91c8134">Shrine of Magh’an Ark’at</card>
     <card qty="1" id="336787ae-5ebc-4104-ae27-7543293d002d">Streets of New York City</card>

--- a/o8g/Decks/203 - Agnes Baker - Bad Blood/Bad Blood.o8d
+++ b/o8g/Decks/203 - Agnes Baker - Bad Blood/Bad Blood.o8d
@@ -43,7 +43,7 @@
     <card qty="1" id="01218ae6-27cf-4827-a256-7557c4ca2341">Bad Blood</card>
     <card qty="1" id="8fc61c54-6c1b-4109-9f64-6cd6bc0f4c50">Northside</card>
     <card qty="1" id="eb341e79-1eb1-46f9-9d25-eff09fe096c9">Downtown</card>
-    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">East Town</card>
+    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">Easttown</card>
     <card qty="1" id="945f53f9-9302-4010-812d-c7b717b2a81d">Miskatonic University</card>
     <card qty="1" id="2e8e4d5e-5c7d-412b-9971-73b7b920de6d">Rivertown</card>
     <card qty="1" id="06176be8-6bd0-4a8a-b2f4-fd8989f41647">Town Hall</card>

--- a/o8g/Decks/204 - Roland Banks - By the Book/By the Book.o8d
+++ b/o8g/Decks/204 - Roland Banks - By the Book/By the Book.o8d
@@ -30,7 +30,7 @@
   </section>
   <section name="Location" shared="True" />
   <section name="Special" shared="True">
-    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">Wolf-man Drew</card>
+    <card qty="1" id="0c7de731-8902-4514-89dc-efaea8796661">"Wolf-Man" Drew</card>
     <card qty="1" id="8ebd7f12-7dfd-46fa-9df9-5a869e752740">Herman Collins</card>
     <card qty="1" id="2dc5134a-a78c-4063-bcca-be24ee436798">Peter Warren</card>
     <card qty="1" id="2eabec3d-6cc1-4b54-8fd0-f4640da8986b">Victoria Devereux</card>
@@ -49,7 +49,7 @@
     <card qty="1" id="b66282e2-c327-4e19-9348-3a720cc165e4">Downtown</card>
     <card qty="1" id="63f426b9-f246-43ca-ad9b-edac00402576">St. Mary's Hospital</card>
     <card qty="1" id="945f53f9-9302-4010-812d-c7b717b2a81d">Miskatonic University</card>
-    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">East Town</card>
+    <card qty="1" id="2a79a0a2-400e-464f-a956-95550312101c">Easttown</card>
     <card qty="1" id="45640790-e6ac-47e2-ab27-73f030fc3e9c">Graveyard</card>
     <card qty="1" id="8fc61c54-6c1b-4109-9f64-6cd6bc0f4c50">Northside</card>
     <card qty="1" id="aaef0de4-b9c7-483b-b0a1-11a6606063a2">Arkham Police Station</card>

--- a/o8g/Sets/A Light in the Fog/set.xml
+++ b/o8g/Sets/A Light in the Fog/set.xml
@@ -487,6 +487,7 @@
     <card id="7cb4b8b4-f309-49fc-b1d5-6caac1395a0f" name="Oceiros Marsh" size="EncounterCard">
       <property name="Card Number" value="253" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Keeper of the Lighthouse" />
       <property name="Encounter Set" value="A Light in the Fog" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Deep One. Hybrid. Elite." />

--- a/o8g/Sets/A Phantom of Truth/set.xml
+++ b/o8g/Sets/A Phantom of Truth/set.xml
@@ -151,14 +151,16 @@
     <property name="Card Number" value="200"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="A Phantom of Truth"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;α: -X. X is the amount of doom in play (max 5).&#10;β: -2. If you fail, move each unengaged Byakhee in play once toward the nearest investigator.&#10;γ: -3. Cancel the effects and icons of each skill card committed to this test.&#10;δ: -2. If you fail, lose 1 resource for each point you failed by."/>
+    <property name="Text" value="α: -X. X is the amount of doom in play (max 5).&#10;β: -2. If you fail, move each unengaged Byakhee in play once toward the nearest investigator.&#10;γ: -3. Cancel the effects and icons of each skill card committed to this test.&#10;δ: -2. If you fail, lose 1 resource for each point you failed by."/>
     <alternate name="A Phantom of Truth" type="B">
       <property name="Encounter Set" value="A Phantom of Truth"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;α: -X. X is the amount of doom in play.&#10;β: -2. Move each unengaged Byakhee in play once toward the nearest investigator.&#10;γ: -4. Cancel the effects and icons of each skill card committed to this test.&#10;δ: -3. If you fail, lose 1 resource for each point you failed by."/>
+      <property name="Text" value="α: -X. X is the amount of doom in play.&#10;β: -2. Move each unengaged Byakhee in play once toward the nearest investigator.&#10;γ: -4. Cancel the effects and icons of each skill card committed to this test.&#10;δ: -3. If you fail, lose 1 resource for each point you failed by."/>
     </alternate>
   </card>
   <card id="157a0781-961a-454e-9d54-15e69ece8ebe" name="The First Night" size="HorizCard">

--- a/o8g/Sets/A Thousand Shapes of Horror/set.xml
+++ b/o8g/Sets/A Thousand Shapes of Horror/set.xml
@@ -82,7 +82,7 @@
       <property name="Slot" value="Arcane" />
       <property name="Skill Icons" value="ά" />
     </card>
-    <card id="32d5fc8d-d784-4dec-b747-7be41b6d95f8" name="“Let God sort them out...”">
+    <card id="32d5fc8d-d784-4dec-b747-7be41b6d95f8" name="“Let God sort them out…”">
       <property name="Card Number" value="160" />
       <property name="Quantity" value="2" />
       <property name="Type" value="Event" />
@@ -115,6 +115,7 @@
     <card id="dfe88206-90fd-4e7f-8c20-4b477b27adb2" name="Gregory Gry">
       <property name="Card Number" value="162" />
       <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Muckraker"/>
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ally. Criminal. Dreamer." />
       <property name="Text" value="Uses (9 resources).&#10;ι When you initiate a skill test, spend up to 3 resources from Gregory Gry: If this test succeeds by at least that amount, gain that many resources." />
@@ -210,10 +211,12 @@
       <property name="Card Number" value="168" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="A Thousand Shapes of Horror" />
+      <property name="Subtitle" value="EASY / STANDARD"/>
       <property name="Type" value="Scenario" />
       <property name="Text" value="α: –1 (–3 instead if you are at a Graveyard location).&#10;β: Reveal another token. If you fail and The Unnamable is in play, it attacks you (regardless of its current location).&#10;γ: +2. The black cat causes a distraction. If this test is successful, choose and evade an enemy at any location with a fight value of X or lower, where X is the amount you succeeded by.&#10;δ: –2. If you fail, you must either place 1 of your clues on your location or take 1 damage." />
       <alternate name="A Thousand Shapes of Horror" size="EncounterCard" type="B">
         <property name="Encounter Set" value="A Thousand Shapes of Horror" />
+        <property name="Subtitle" value="HARD / EXPERT"/>
         <property name="Type" value="Scenario" />
         <property name="Text" value="α: –2 (–4 instead if you are at a Graveyard location).&#10;β: Reveal another token. If you fail and The Unnamable is in play, it attacks you (regardless of its current location).&#10;γ: +1. The black cat causes a distraction. If this test is successful, choose and evade an enemy at any location with a fight value of X or lower, where X is the amount you succeeded by.&#10;δ: –3. If you fail, you must either place 1 of your clues on your location or take 1 damage." />
       </alternate>
@@ -225,7 +228,7 @@
       <property name="Subtitle" value="Agenda 1a" />
       <property name="Type" value="Agenda" />
       <property name="Doom" value="5" />
-      <alternate name="The Unnameable" size="EncounterCard" type="B">
+      <alternate name="The Unnamable" size="EncounterCard" type="B">
         <property name="Encounter Set" value="A Thousand Shapes of Horror" />
         <property name="Subtitle" value="The Ultimate Abomination" />
         <property name="Type" value="Enemy" />
@@ -260,7 +263,7 @@
       <property name="Type" value="Agenda" />
       <property name="Text" value="Each Swarm of Rats gains swarming 2.&#10;The Unnamable loses aloof and gains massive.&#10;Forced – At the start of your turn, if The Unnamable is ready and at your location: Test ά (2). If you fail, it attacks you (even if it is not engaged with you)." />
       <property name="Doom" value="7" />
-      <alternate name="Is It Real" size="HorizCard" type="B">
+      <alternate name="It Is Real" size="HorizCard" type="B">
         <property name="Encounter Set" value="A Thousand Shapes of Horror" />
         <property name="Subtitle" value="Agenda 3b" />
         <property name="Type" value="Agenda" />

--- a/o8g/Sets/Before the Black Throne/set.xml
+++ b/o8g/Sets/Before the Black Throne/set.xml
@@ -238,7 +238,7 @@
       <property name="Type" value="Agenda" />
       <property name="Text" value="Each location is connected to each location adjacent to it.Do not remove doom from enemies when this agenda advances.&#10;(Beware—The scenario will not end when this agenda advances, but the doom of the world grows nigh.)" />
       <property name="Doom" value="8" />
-      <alternate name="Azathoth Stirs..." size="HorizCard" type="B">
+      <alternate name="Azathoth Stirs…" size="HorizCard" type="B">
         <property name="Encounter Set" value="Before the Black Throne" />
         <property name="Subtitle" value="Agenda 3b" />
         <property name="Type" value="Agenda" />
@@ -325,7 +325,7 @@
       <property name="Encounter Set" value="Before the Black Throne" />
       <property name="Type" value="Location" />
       <property name="Traits" value="Otherworld." />
-      <alternate name="Court of the Great Olds Ones" size="EncounterCard" type="B">
+      <alternate name="Court of the Great Old Ones" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Before the Black Throne" />
         <property name="Type" value="Location" />
         <property name="Traits" value="Otherworld." />
@@ -472,6 +472,7 @@
     <card id="ab2ec5e1-6170-410a-a5b2-767dbfa02f17" name="Azathoth" size="EncounterCard">
       <property name="Card Number" value="346" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="The Primal Chaos"/>
       <property name="Encounter Set" value="Before the Black Throne" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Ancient One. Elite." />

--- a/o8g/Sets/Black Stars Rise/set.xml
+++ b/o8g/Sets/Black Stars Rise/set.xml
@@ -145,14 +145,16 @@
     <property name="Card Number" value="274"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Black Stars Rise"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;&#10;α: -X. X is the highest amount of doom on an agenda in play.&#10;&#10;β: Reveal another token. If this token is revealed during an attack or evasion attempt against an enemy with doom on it, this skill test automatically fails instead.&#10;&#10;γ: Reveal another token. If you fail, place 1 doom on each agenda.&#10;&#10;δ: -2. If you fail, search the encounter deck and discard pile for a Byakhee enemy and draw it."/>
+    <property name="Text" value="α: -X. X is the highest amount of doom on an agenda in play.&#10;β: Reveal another token. If this token is revealed during an attack or evasion attempt against an enemy with doom on it, this skill test automatically fails instead.&#10;γ: Reveal another token. If you fail, place 1 doom on each agenda.&#10;δ: -2. If you fail, search the encounter deck and discard pile for a Byakhee enemy and draw it."/>
     <alternate name="Black Stars Rise" type="B">
       <property name="Encounter Set" value="Black Stars Rise"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;&#10;α: -X. X is the total amount of doom on agendas in play.&#10;&#10;β: Reveal another token. If there is an enemy with 1 or more doom on it at your location, this test automatically fails instead.&#10;&#10;γ: Reveal another token. If you do not succeed by at least 1, place 1 doom on each agenda.&#10;&#10;δ: -3. If you fail, search the encounter deck and discard pile for a Byakhee enemy and draw it."/>
+      <property name="Text" value="α: -X. X is the total amount of doom on agendas in play.&#10;β: Reveal another token. If there is an enemy with 1 or more doom on it at your location, this test automatically fails instead.&#10;γ: Reveal another token. If you do not succeed by at least 1, place 1 doom on each agenda.&#10;δ: -3. If you fail, search the encounter deck and discard pile for a Byakhee enemy and draw it."/>
     </alternate>
   </card>
   <card id="e435831f-c721-49a5-988f-1fe5f59cac1c" name="The Tide Rises" size="HorizCard">

--- a/o8g/Sets/Blood on the Altar/set.xml
+++ b/o8g/Sets/Blood on the Altar/set.xml
@@ -205,8 +205,8 @@
     <property name="Clues" value="-"/>
     <property name="Doom" value=""/>
     <property name="Text" value="Objective – When an investigator enters The Hidden Chamber, advance."/>
-    <alternate name="Searching for Answers" size="HorizCard" type="B">
-      <property name="What Was Hidden" value="Blood on the Altar"/>
+    <alternate name="What Was Hidden" size="HorizCard" type="B">
+      <property name="Encounter Set" value="Blood on the Altar"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="1"/>
       <property name="Shroud" value=""/>

--- a/o8g/Sets/Blood on the Altar/set.xml
+++ b/o8g/Sets/Blood on the Altar/set.xml
@@ -138,7 +138,7 @@
       <property name="Text" value="α: –1 for each location in play with no encounter card underneath it.&#10;β: –4. If you fail, add 1 clue from the token pool to your location.&#10;γ: –3. Reveal another token.&#10;δ: –3. Place 1 doom on the current agenda."/>
     </alternate>
   </card>
-  <card id="a8ba171e-ce59-42fb-90d0-8a08132ae2fc" name="Strange Disapperances" size="HorizCard">
+  <card id="a8ba171e-ce59-42fb-90d0-8a08132ae2fc" name="Strange Disappearances" size="HorizCard">
     <property name="Card Number" value="196"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Blood on the Altar"/>
@@ -147,7 +147,7 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value="6"/>
-    <alternate name="Strange Disapperances" size="HorizCard" type="B">
+    <alternate name="First Blood" size="HorizCard" type="B">
       <property name="Encounter Set" value="Blood on the Altar"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="1"/>
@@ -166,7 +166,7 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value="6"/>
-    <alternate name="The Old Ones Hunger" size="HorizCard" type="B">
+    <alternate name="Abandoned Streets" size="HorizCard" type="B">
       <property name="Encounter Set" value="Blood on the Altar"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="2"/>
@@ -185,7 +185,7 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value="7"/>
-    <alternate name="Feed the Beast" size="HorizCard" type="B">
+    <alternate name="Blood on the Altar" size="HorizCard" type="B">
       <property name="Encounter Set" value="Blood on the Altar"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="3"/>
@@ -206,7 +206,7 @@
     <property name="Doom" value=""/>
     <property name="Text" value="Objective – When an investigator enters The Hidden Chamber, advance."/>
     <alternate name="Searching for Answers" size="HorizCard" type="B">
-      <property name="Encounter Set" value="Blood on the Altar"/>
+      <property name="What Was Hidden" value="Blood on the Altar"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="1"/>
       <property name="Shroud" value=""/>
@@ -225,7 +225,7 @@
     <property name="Clues" value="-"/>
     <property name="Doom" value=""/>
     <property name="Text" value="Objective – If Silas Bishop is defeated: (->R1)&#10;Objective – If there are no clues in the Hidden Chamber, advance."/>
-    <alternate name="The Chamber of the Beast" size="HorizCard" type="B">
+    <alternate name="Banishing the Creature" size="HorizCard" type="B">
       <property name="Encounter Set" value="Blood on the Altar"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="2"/>
@@ -485,6 +485,7 @@
   <card id="47bc5ee8-9537-417b-8cf9-d700139caa73" name="The Hidden Chamber" size="EncounterCard">
     <property name="Card Number" value="214"/>
     <property name="Quantity" value="1"/>
+    <property name="Subtitle" value="Prison of the Beast"/>
     <property name="Encounter Set" value="Blood on the Altar"/>
     <property name="Type" value="Location"/>
     <property name="Shroud" value="3"/>
@@ -538,7 +539,7 @@
     <property name="Card Number" value="218"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Blood on the Altar"/>
-    <property name="Subtitle" value="Smarter Than He Looks"/>
+    <property name="Subtitle" value="Smarter Than He Lets On"/>
     <property name="Unique" value="*"/>
     <property name="Type" value="Asset"/>
     <property name="Cost" value="3"/>

--- a/o8g/Sets/Book Series/set.xml
+++ b/o8g/Sets/Book Series/set.xml
@@ -80,6 +80,7 @@
       <property name="Unique" value="ο"/>
       <property name="Type" value="Investigator"/>
       <property name="Class" value="Guardian"/>
+      <property name="Text" value="Deck Size: 30.&#10;Deckbuilding Options: Guardian cards (κ) level 0-5, Seeker cards (λ) level 0-2, Neutral cards level 0-5.&#10;Deckbuilding Requirements (do not count toward deck size): Roland's .38 Special, Cover Up, 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="76ff41d5-274d-438b-8e3e-1137d77fe6e7" name="Roland Banks" size="MiniCard">
@@ -215,7 +216,7 @@
     <property name="Skill Icons" value="ΰΰ"/>
     <property name="Slot" value="Ally"/>
     <property name="Traits" value="Ally. Creature. Dreamlands."/>
-    <property name="Text" value="Carolyn Fern deck only. Replacement.Foolishness enters play with 3 horror on him. Horror on him may be healed as if it were on Carolyn Fern. While Foolishness has no horror on him, you get +1 to all skills."/>
+    <property name="Text" value="Carolyn Fern deck only. Replacement.&#10;Foolishness enters play with 3 horror on him. Horror on him may be healed as if it were on Carolyn Fern. While Foolishness has no horror on him, you get +1 to all skills."/>
   </card>
   <card id="90bae4d6-e012-4a80-9a98-8d85211efb13" name="To Fight the Black Wind">
     <property name="Card Number" value="12"/>
@@ -224,7 +225,7 @@
     <property name="Class" value="Neutral"/>
     <property name="Subtype" value="Weakness"/>
     <property name="Traits" value="Task. Dreamlands."/>
-    <property name="Text" value="Carolyn Fern deck only. Replacement.Revelation - Attach To Fight the Black Wind to the current agenda. Carolyn Fern takes 1 direct horror.Forced - At the end of the round, if any amount of horror was assigned to an investigator this round and it was not healed: Place 1 doom on attached agenda."/>
+    <property name="Text" value="Carolyn Fern deck only. Replacement.&#10;Revelation - Attach To Fight the Black Wind to the current agenda. Carolyn Fern takes 1 direct horror.Forced - At the end of the round, if any amount of horror was assigned to an investigator this round and it was not healed: Place 1 doom on attached agenda."/>
   </card>
   <card id="d1a85eac-aaae-4267-9608-91588834ae68" name="Silas Marsh" size="InvestigatorCard">
     <property name="Card Number" value="13"/>
@@ -267,7 +268,7 @@
     <property name="Intellect" value="1"/>
     <property name="Skill Icons" value="έάΰ"/>
     <property name="Traits" value="Innate. Developed."/>
-    <property name="Text" value="Silas Marsh deck only. Replacement.If a chaos token with a negative modifier is revealed during this test, either draw 1 card or Nautical Prowess gains ΰΰ"/>
+    <property name="Text" value="Silas Marsh deck only. Replacement.&#10;If a chaos token with a negative modifier is revealed during this test, either draw 1 card or Nautical Prowess gains ΰΰ"/>
   </card>
   <card id="32cc7955-1b67-4ab4-9c5b-b2ffa80257e0" name="Dreams of the Deep">
     <property name="Card Number" value="15"/>
@@ -278,7 +279,7 @@
     <property name="Subtype" value="Weakness"/>
     <property name="Skill Icons" value="ΰΰ"/>
     <property name="Traits" value="Curse."/>
-    <property name="Text" value="Silas Marsh deck only. Replacement.This skill's icons subtract from your skill value instead of adding to it.If this skill test fails, return this skill to your hand.Forced - If Dreams of the Deep is in your hand at the end of your turn: Reveal it and take 2 damage."/>
+    <property name="Text" value="Silas Marsh deck only. Replacement.&#10;This skill's icons subtract from your skill value instead of adding to it.If this skill test fails, return this skill to your hand.Forced - If Dreams of the Deep is in your hand at the end of your turn: Reveal it and take 2 damage."/>
   </card>
   <card id="d47f1653-8eff-4bc1-aea6-90d7eb7fbaa9" name="Dexter Drake" size="InvestigatorCard">
     <property name="Card Number" value="16"/>
@@ -357,7 +358,7 @@
       <property name="Type" value="Investigator"/>
       <property name="Class" value="Mystic"/>
       <property name="Traits" value="Clairvoyant."/>
-      <property name="Text" value="Deck Size: 30.&#10;Secondary Class Choise: At deck creation, choose Guardian (κ), Seeker (λ), or Rogue (ν).&#10;Deckbuilding Options: Mystic cards (μ) level 0-5, Neutral cards level 0-5, up to 10 level 0-1 events and/or skills of your chosen secondary class.&#10;Deckbuilding Requirements (do not count toward deck size): 3 copies of Psychic Sensitivity, 3 copies of Prophecy of the End (shuffled into the encounter deck), 1 random basic weakness."/>
+      <property name="Text" value="Deck Size: 30.&#10;Secondary Class Choice: At deck creation, choose Guardian (κ), Seeker (λ), or Rogue (ν).&#10;Deckbuilding Options: Mystic cards (μ) level 0-5, Neutral cards level 0-5, up to 10 level 0-1 events and/or skills of your chosen secondary class.&#10;Deckbuilding Requirements (do not count toward deck size): 3 copies of Psychic Sensitivity, 3 copies of Prophecy of the End (shuffled into the encounter deck), 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="a6d5e2f7-e621-49c7-af77-5a2c21d6c403" name="Gloria Goldberg" size="MiniCard">

--- a/o8g/Sets/Carnevale of Horrors/set.xml
+++ b/o8g/Sets/Carnevale of Horrors/set.xml
@@ -5,12 +5,14 @@
     <property name="Card Number" value="1"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Carnevale of Horrors"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="Easy / Standard&#10;α: -2. This token has an additional -1 for each Innocent Reveler underneath the agenda deck.&#10;β: Reveal another token. If you fail this test, draw the top card of the encounter deck.&#10;γ: -3. If you fail, deal 1 damage or 1 horror to the nearest Innocent Reveler in play.&#10;δ: -4. If you fail and Cnidathqua is in play, it attacks you."/>
+    <property name="Text" value="α: -2. This token has an additional -1 for each Innocent Reveler underneath the agenda deck.&#10;β: Reveal another token. If you fail this test, draw the top card of the encounter deck.&#10;γ: -3. If you fail, deal 1 damage or 1 horror to the nearest Innocent Reveler in play.&#10;δ: -4. If you fail and Cnidathqua is in play, it attacks you."/>
     <alternate name="Carnevale of Horrors" type="B">
       <property name="Encounter Set" value="Carnevale of Horrors"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="Hard / Expert&#10;α: -2. This token has an additional -1 for each Innocent Reveler underneath the act or agenda decks.&#10;β: Reveal another token. If you fail this test, draw the top card of the encounter deck.&#10;γ: -4. Deal 1 damage or 1 horror to the nearest Innocent Reveler in play.&#10;δ: -6. If you fail and Cnidathqua is in play, it attacks you."/>
+      <property name="Text" value="α: -2. This token has an additional -1 for each Innocent Reveler underneath the act or agenda decks.&#10;β: Reveal another token. If you fail this test, draw the top card of the encounter deck.&#10;γ: -4. Deal 1 damage or 1 horror to the nearest Innocent Reveler in play.&#10;δ: -6. If you fail and Cnidathqua is in play, it attacks you."/>
     </alternate>
   </card>
   <card id="df403021-1bf1-41f5-b043-23a1cf8a4471" name="The Festivities Begin" size="HorizCard">
@@ -50,7 +52,7 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value="3"/>
-    <alternate name="The Shadow of the Eclipse" size="HorizCard" type="B">
+    <alternate name="A Sacrifice To Be Made" size="HorizCard" type="B">
       <property name="Encounter Set" value="Carnevale of Horrors"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="2"/>
@@ -70,7 +72,7 @@
     <property name="Clues" value=""/>
     <property name="Doom" value="3"/>
     <property name="Text" value="Forced - After a Writhing Appendage enters play: Place 2 doom on it."/>
-    <alternate name="Chaos at the Carnevale" size="HorizCard" type="B">
+    <alternate name="Cnidathqua Attacks!" size="HorizCard" type="B">
       <property name="Encounter Set" value="Carnevale of Horrors"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="3"/>
@@ -90,7 +92,7 @@
     <property name="Clues" value="0"/>
     <property name="Doom" value=""/>
     <property name="Text" value="η The investigators spend 1π  clues, as a group: Look at the other side of a Masked Carnevale-Goer at any location.&#10;Objective - If there are a total of 3 Innocent Revelers underneath the act and/or agenda decks, advance."/>
-    <alternate name="The Carnevale Conspiracy" size="HorizCard" type="B">
+    <alternate name="Beast Emerges" size="HorizCard" type="B">
       <property name="Encounter Set" value="Carnevale of Horrors"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="1"/>
@@ -130,7 +132,7 @@
     <property name="Clues" value="0"/>
     <property name="Doom" value=""/>
     <property name="Text" value="Objective - If there are 4π  resources on Gondola, advance."/>
-    <alternate name="Row!" size="HorizCard" type="B">
+    <alternate name="Blood of the Lagoon" size="HorizCard" type="B">
       <property name="Encounter Set" value="Carnevale of Horrors"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="3"/>
@@ -180,7 +182,7 @@
       <property name="Text" value="Canal-side is connected to the location in the clockwise direction.&#10;ι After you enter Canal-side: Place 1 clue on Canal-side from the token bank."/>
     </alternate>
   </card>
-  <card id="08f83237-d86e-4f23-abd7-4ff1db2873f8" name="Streets of Veince" size="EncounterCard">
+  <card id="08f83237-d86e-4f23-abd7-4ff1db2873f8" name="Streets of Venice" size="EncounterCard">
     <property name="Card Number" value="10"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Carnevale of Horrors"/>
@@ -189,15 +191,15 @@
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
     <property name="Traits" value="Venice."/>
-    <property name="Text" value="Streets of Veince is connected to the location in the clockwise direction."/>
-    <alternate name="Streets of Veince" size="EncounterCard" type="B">
+    <property name="Text" value="Streets of Venice is connected to the location in the clockwise direction."/>
+    <alternate name="Streets of Venice" size="EncounterCard" type="B">
       <property name="Encounter Set" value="Carnevale of Horrors"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="2"/>
       <property name="Clues" value="2"/>
       <property name="Doom" value=""/>
       <property name="Traits" value="Venice."/>
-      <property name="Text" value="Streets of Veince is connected to the location in the clockwise direction.&#10;θ: Move (to the location in the clockwise direction)."/>
+      <property name="Text" value="Streets of Venice is connected to the location in the clockwise direction.&#10;θ: Move (to the location in the clockwise direction)."/>
     </alternate>
   </card>
   <card id="0cc17a30-bd37-41a0-b8ed-c0fef10abb97" name="Rialto Bridge" size="EncounterCard">
@@ -348,7 +350,7 @@
     <property name="Class" value="Neutral"/>
     <property name="Traits" value="Carnevale."/>
     <property name="Text" value="η Spend 1 clue: Flip Masked Carnevale-Goer. If its other side is an enemy, it attacks each investigator in its location."/>
-    <alternate name="Elisabetta Margo" type="B" size="EncounterCard">
+    <alternate name="Elisabetta Magro" type="B" size="EncounterCard">
       <property name="Card Number" value="18"/>
       <property name="Quantity" value="1"/>
       <property name="Encounter Set" value="Carnevale of Horrors"/>
@@ -362,7 +364,7 @@
       <property name="Horror" value="1"/>
       <property name="Victory Points" value="1"/>
       <property name="Traits" value="Humanoid. Lodge. Elite."/>
-      <property name="Text" value="Aloof.&#10;Forced - When you look at Elisabetta Margo using the ability on Act 1a: Flip her to this side.&#10;Forced - When the mythos phase ends: Place 1 doom on Elisabetta Margo."/>
+      <property name="Text" value="Aloof.&#10;Forced - When you look at Elisabetta Magro using the ability on Act 1a: Flip her to this side.&#10;Forced - When the mythos phase ends: Place 1 doom on Elisabetta Magro."/>
     </alternate>
   </card>
   <card id="7dd9e264-2dce-40e2-be80-44ce5285430b" name="Masked Carnevale-Goer" size="EncounterCard">

--- a/o8g/Sets/Core Set/set.xml
+++ b/o8g/Sets/Core Set/set.xml
@@ -21,6 +21,7 @@
       <property name="Unique" value="ο"/>
       <property name="Type" value="Investigator"/>
       <property name="Class" value="Guardian"/>
+      <property name="Text" value="Deck Size: 30.&#10;Deckbuilding Options: Guardian cards (κ) level 0-5, Seeker cards (λ) level 0-2, Neutral cards level 0-5.&#10;Deckbuilding Requirements (do not count toward deck size): Roland's .38 Special, Cover Up, 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="53463cb2-2261-4d8b-b948-d8f7a926ed79" name="Daisy Walker" size="InvestigatorCard">
@@ -43,6 +44,7 @@
       <property name="Unique" value="ο"/>
       <property name="Type" value="Investigator"/>
       <property name="Class" value="Seeker"/>
+      <property name="Text" value="Deck Size: 30.&#10;Deckbuilding Options: Seeker cards (λ) level 0-5, Mystic cards (μ) level 0-2, Neutral cards level 0-5.&#10;Deckbuilding Requirements (do not count toward deck size): Daisy's Tote Bag, The Necronomicon (John Dee Translation), 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="4074eb1e-2341-4ff8-be20-d220621fa3c4" name="&quot;Skids&quot; O'Toole" size="InvestigatorCard">
@@ -65,6 +67,7 @@
       <property name="Unique" value="ο"/>
       <property name="Type" value="Investigator"/>
       <property name="Class" value="Rogue"/>
+      <property name="Text" value="Deck Size: 30.&#10;Deckbuilding Options: Rogue cards (ν) level 0-5, Guardian cards (κ) level 0-2, Neutral cards level 0-5.&#10;Deckbuilding Requirements (do not count toward deck size): On the Lam, Hospital Debts, 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="207654c5-69a2-467b-b4ab-bfeffd28d310" name="Agnes Baker" size="InvestigatorCard">
@@ -87,6 +90,7 @@
       <property name="Unique" value="ο"/>
       <property name="Type" value="Investigator"/>
       <property name="Class" value="Mystic"/>
+      <property name="Text" value="Deck Size: 30.&#10;Deckbuilding Options: Mystic cards (μ) level 0-5, Survivor cards (ξ) level 0-2, Neutral cards level 0-5.&#10;Deckbuilding Requirements (do not count toward deck size): Heirloom of Hyperborea, Dark Memory, 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="e8b6e380-16f3-40d7-af47-484db614ea18" name="Wendy Adams" size="InvestigatorCard">
@@ -109,6 +113,7 @@
       <property name="Unique" value="ο"/>
       <property name="Type" value="Investigator"/>
       <property name="Class" value="Survivor"/>
+      <property name="Text" value="Deck Size: 30.&#10;Deckbuilding Options: Survivor cards (ξ) level 0-5, Rogue cards (ν) level 0-2, Neutral cards level 0-5.&#10;Deckbuilding Requirements (do not count toward deck size): Wendy's Amulet, Abandoned and Alone, 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="4bb7b957-a180-4421-ad42-49704e11a3a5" name="Roland's .38 Special">
@@ -1346,12 +1351,12 @@
     <property name="Encounter Set" value="The Gathering"/>
     <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="α -X. X is the number of Ghoul enemies at your location.&#10;β -1. If you fail, take 1 horror.&#10;γ -2. If there is a Ghoul enemy at your location, take 1 damage.&#10;"/>
+    <property name="Text" value="α: -X. X is the number of Ghoul enemies at your location.&#10;β: -1. If you fail, take 1 horror.&#10;γ: -2. If there is a Ghoul enemy at your location, take 1 damage."/>
     <alternate name="The Gathering" type="B">
       <property name="Encounter Set" value="The Gathering"/>
       <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="α -2. If you fail, after this skill test, search the encounter deck and discard pile for a Ghoul enemy, and draw it. Shuffle the encounter deck.β Reveal another token. If you fail, take 2 horror.γ -4. If there is a Ghoul enemy at your location, take 1 damage and 1 horror.&#10;"/>
+      <property name="Text" value="α: -2. If you fail, after this skill test, search the encounter deck and discard pile for a Ghoul enemy, and draw it. Shuffle the encounter deck.&#10;β: Reveal another token. If you fail, take 2 horror.&#10;γ: -4. If there is a Ghoul enemy at your location, take 1 damage and 1 horror."/>
     </alternate>
   </card>
   <card id="28a33b22-2f33-437c-8ca4-3c12e3d86fb2" name="What's Going On?!" size="HorizCard">
@@ -1617,12 +1622,12 @@
     <property name="Encounter Set" value="The Midnight Masks"/>
     <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="α -X. X is the highest number of doom on a Cultist enemy in play.&#10;β -2. Place 1 doom on the nearest cultist enemy.γ -3. If you fail, place 1 of your clues on your location."/>
+    <property name="Text" value="α: -X. X is the highest number of doom on a Cultist enemy in play.&#10;β: -2. Place 1 doom on the nearest cultist enemy.&#10;γ: -3. If you fail, place 1 of your clues on your location."/>
     <alternate name="The Midnight Masks" type="B">
       <property name="Encounter Set" value="The Midnight Masks"/>
       <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="α -X. X is the total number of doom in play.β -2. Place 1 doom on each Cultist enemy in play. If there are no Cultist enemies in play, reveal another token.γ -4. If you fail, place all your clues on your location."/>
+      <property name="Text" value="α: -X. X is the total number of doom in play.&#10;β: -2. Place 1 doom on each Cultist enemy in play. If there are no Cultist enemies in play, reveal another token.&#10;γ: -4. If you fail, place all your clues on your location."/>
     </alternate>
   </card>
   <card id="d533f5ae-53fc-4bbb-96b9-d0f26364c387" name="Predator or Prey" size="HorizCard">
@@ -1669,7 +1674,7 @@
     <property name="Keywords" value="Spawn - Engaged with prey.Prey - Most Clues.Hunter."/>
     <property name="Text" value="The Masked Hunter gets +2 health per investigator.While you are engaged with The Masked Hunter, you cannot discover or spend clues."/>
   </card>
-  <card id="193ea5c4-b871-4b10-9672-dde886264264" name="Time is Running Short" size="HorizCard">
+  <card id="193ea5c4-b871-4b10-9672-dde886264264" name="Time Is Running Short" size="HorizCard">
     <property name="Card Number" value="122"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Midnight Masks"/>
@@ -1865,7 +1870,7 @@
       <property name="Text" value="η: Heal 3 horror. (Limit once per game.)"/>
     </alternate>
   </card>
-  <card id="2a79a0a2-400e-464f-a956-95550312101c" name="East Town" size="EncounterCard">
+  <card id="2a79a0a2-400e-464f-a956-95550312101c" name="Easttown" size="EncounterCard">
     <property name="Card Number" value="132"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Midnight Masks"/>
@@ -1874,7 +1879,7 @@
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
     <property name="Traits" value="Arkham."/>
-    <alternate name="East Town" size="EncounterCard" type="B">
+    <alternate name="Easttown" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Midnight Masks"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="2"/>
@@ -1940,10 +1945,10 @@
     <property name="Type" value="Treachery"/>
     <property name="Text" value="Revelation - If you have no clues, False Lead gains surge. If you have 1 or more clues, test έ (4). For each point you fail, place 1 of your clues on your location."/>
   </card>
-  <card id="0c7de731-8902-4514-89dc-efaea8796661" name="Wolf-man Drew" size="EncounterCard">
+  <card id="0c7de731-8902-4514-89dc-efaea8796661" name="&quot;Wolf-Man&quot; Drew" size="EncounterCard">
     <property name="Card Number" value="137"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Cult of Umordhoth"/>
+    <property name="Encounter Set" value="Cult of Umôrdhoth"/>
     <property name="Subtitle" value="The Cannibal"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Enemy"/>
@@ -1955,12 +1960,12 @@
     <property name="Victory Points" value="1"/>
     <property name="Traits" value="Humanoid. Cultist."/>
     <property name="Keywords" value="Spawn - Downtown."/>
-    <property name="Text" value="Forced - When Wolf-man Drew attacks: Heal 1 damage from him."/>
+    <property name="Text" value="Forced - When &quot;Wolf-Man&quot; Drew attacks: Heal 1 damage from him."/>
   </card>
   <card id="8ebd7f12-7dfd-46fa-9df9-5a869e752740" name="Herman Collins" size="EncounterCard">
     <property name="Card Number" value="138"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Cult of Umordhoth"/>
+    <property name="Encounter Set" value="Cult of Umôrdhoth"/>
     <property name="Subtitle" value="The Undertaker"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Enemy"/>
@@ -1977,7 +1982,7 @@
   <card id="2dc5134a-a78c-4063-bcca-be24ee436798" name="Peter Warren" size="EncounterCard">
     <property name="Card Number" value="139"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Cult of Umordhoth"/>
+    <property name="Encounter Set" value="Cult of Umôrdhoth"/>
     <property name="Subtitle" value="The Occult Professor"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Enemy"/>
@@ -1994,7 +1999,7 @@
   <card id="2eabec3d-6cc1-4b54-8fd0-f4640da8986b" name="Victoria Devereux" size="EncounterCard">
     <property name="Card Number" value="140"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Cult of Umordhoth"/>
+    <property name="Encounter Set" value="Cult of Umôrdhoth"/>
     <property name="Subtitle" value="The Collector"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Enemy"/>
@@ -2011,7 +2016,7 @@
   <card id="fc6b957f-5e19-46a7-b742-029f8f9fa5b5" name="Ruth Turner" size="EncounterCard">
     <property name="Card Number" value="141"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Cult of Umordhoth"/>
+    <property name="Encounter Set" value="Cult of Umôrdhoth"/>
     <property name="Subtitle" value="The Mortician"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Enemy"/>
@@ -2031,12 +2036,12 @@
     <property name="Encounter Set" value="The Devourer Below"/>
     <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="α -X. X is the number of Monster enemies in play.&#10;β -2. Place 1 doom on the nearest enemy.γ -3. If there is a Monster enemy at your location, take 1 damage.δ -5. If there is an Ancient One enemy in play, reveal another token."/>
+    <property name="Text" value="α: -X. X is the number of Monster enemies in play.&#10;β: -2. Place 1 doom on the nearest enemy.&#10;γ: -3. If there is a Monster enemy at your location, take 1 damage.&#10;δ: -5. If there is an Ancient One enemy in play, reveal another token."/>
     <alternate name="The Devourer Below" type="B">
       <property name="Encounter Set" value="The Devourer Below"/>
       <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="α -3. If you fail, after this skill test, search the encounter deck and discard pile for a Monster enemy, and draw it. Shuffle the encounter deck.β -4. Place 2 doom on the nearest enemy.γ -5. If there is a Monster enemy at your location, take 1 damage and 1 horror.δ -7. If there is an Ancient One enemy in play, reveal another token."/>
+      <property name="Text" value="α: -3. If you fail, after this skill test, search the encounter deck and discard pile for a Monster enemy, and draw it. Shuffle the encounter deck.&#10;β: -4. Place 2 doom on the nearest enemy.&#10;γ: -5. If there is a Monster enemy at your location, take 1 damage and 1 horror.&#10;δ: -7. If there is an Ancient One enemy in play, reveal another token."/>
     </alternate>
   </card>
   <card id="12eb456d-9abb-4a7b-9b7f-ebb252772874" name="The Arkham Woods" size="HorizCard">
@@ -2068,7 +2073,7 @@
     <property name="Clues" value=""/>
     <property name="Doom" value="5"/>
     <property name="Text" value="Each enemy gets +1 fight and +1 evade."/>
-    <alternate name="The Will of Umordhoth" size="HorizCard" type="B">
+    <alternate name="The Will of Umôrdhoth" size="HorizCard" type="B">
       <property name="Encounter Set" value="The Devourer Below"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="2"/>
@@ -2087,7 +2092,7 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value="5"/>
-    <property name="Text" value="Fored - When this agenda advances:If the investigators are at Act 1, put the set-aside Ritual Site into play and spawn the set-aside Umordhoth there.If the investigators are at Act 2 or 3, discard all enemies at the Ritual Site and spawn the set-aside Umordhoth there."/>
+    <property name="Text" value="Fored - When this agenda advances:If the investigators are at Act 1, put the set-aside Ritual Site into play and spawn the set-aside Umôrdhoth there.If the investigators are at Act 2 or 3, discard all enemies at the Ritual Site and spawn the set-aside Umôrdhoth there."/>
     <alternate name="The Devourer Below" size="HorizCard" type="B">
       <property name="Encounter Set" value="The Devourer Below"/>
       <property name="Type" value="Agenda"/>
@@ -2095,7 +2100,7 @@
       <property name="Shroud" value=""/>
       <property name="Clues" value=""/>
       <property name="Doom" value=""/>
-      <property name="Text" value="Revelation - Replace the current Act and Agenda with The Devourer Below. This card is both the current Act and the current Agenda.Objective - If Umordhoth is defeated, (R2)."/>
+      <property name="Text" value="Revelation - Replace the current Act and Agenda with The Devourer Below. This card is both the current Act and the current Agenda.Objective - If Umôrdhoth is defeated, (R2)."/>
     </alternate>
   </card>
   <card id="f5fcd3ba-665b-4631-a478-35c3bcfd9a84" name="Investigating the Trail" size="HorizCard">
@@ -2147,7 +2152,7 @@
     <property name="Clues" value="-"/>
     <property name="Doom" value=""/>
     <property name="Text" value="η Spend 1 clue: Test ά (3) or ί (3). If you succeed, place 1 clue on this Act.Objective - If there are 2 clues per investigator on this Act, advance."/>
-    <alternate name="The Ritual is Broken" size="HorizCard" type="B">
+    <alternate name="The Ritual Is Broken" size="HorizCard" type="B">
       <property name="Encounter Set" value="The Devourer Below"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="3"/>
@@ -2315,7 +2320,7 @@
       <property name="Text" value="Forced - At the end of the round, if there are fewer than 2 clues per investigator on Ritual Site: add clues to it until it has 2 clues per investigator on it."/>
     </alternate>
   </card>
-  <card id="2b4c8caa-4e83-444e-b73d-bee8a0a96063" name="Umordhoth" size="EncounterCard">
+  <card id="2b4c8caa-4e83-444e-b73d-bee8a0a96063" name="Umôrdhoth" size="EncounterCard">
     <property name="Card Number" value="157"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Devourer Below"/>
@@ -2328,7 +2333,7 @@
     <property name="Horror" value="3"/>
     <property name="Traits" value="Ancient One. Elite."/>
     <property name="Keywords" value="Hunter. Massive."/>
-    <property name="Text" value="Umordhoth gets +4 health per investigator.Forced - At the end of each investigator's turn: Ready Umordhoth.η If you control Lita Chandler: &quot;It's only after her!&quot; You throw Lita to Umordhoth in order to spare your lives. (R3)"/>
+    <property name="Text" value="Umôrdhoth gets +4 health per investigator.Forced - At the end of each investigator's turn: Ready Umôrdhoth.η If you control Lita Chandler: &quot;It's only after her!&quot; You throw Lita to Umôrdhoth in order to spare your lives. (R3)"/>
   </card>
   <card id="013a94df-b579-4670-9dc6-0176dad396a8" name="Umôrdhoth's Wrath" size="EncounterCard">
     <property name="Card Number" value="158"/>

--- a/o8g/Sets/Core Set/set.xml
+++ b/o8g/Sets/Core Set/set.xml
@@ -2341,7 +2341,7 @@
     <property name="Encounter Set" value="The Devourer Below"/>
     <property name="Type" value="Treachery"/>
     <property name="Traits" value="Curse."/>
-    <property name="Text" value="Revelation - Test ά (5). For each point you fail by, you must either (choose one): Choose and discard a card from your hand, or take 1 damage and 2 horror."/>
+    <property name="Text" value="Revelation - Test ά (5). For each point you fail by, you must either (choose one): Choose and discard a card from your hand, or take 1 damage and 1 horror."/>
   </card>
   <card id="76a906b0-eea1-4ce1-9982-f7e0f1aab553" name="Swarm of Rats" size="EncounterCard">
     <property name="Card Number" value="159"/>

--- a/o8g/Sets/Core Set/set.xml
+++ b/o8g/Sets/Core Set/set.xml
@@ -1630,7 +1630,7 @@
       <property name="Text" value="α: -X. X is the total number of doom in play.&#10;β: -2. Place 1 doom on each Cultist enemy in play. If there are no Cultist enemies in play, reveal another token.&#10;γ: -4. If you fail, place all your clues on your location."/>
     </alternate>
   </card>
-  <card id="d533f5ae-53fc-4bbb-96b9-d0f26364c387" name="Predator or Prey" size="HorizCard">
+  <card id="d533f5ae-53fc-4bbb-96b9-d0f26364c387" name="Predator or Prey?" size="HorizCard">
     <property name="Card Number" value="121"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Midnight Masks"/>

--- a/o8g/Sets/Curse of the Rougarou/set.xml
+++ b/o8g/Sets/Curse of the Rougarou/set.xml
@@ -7,12 +7,12 @@
     <property name="Encounter Set" value="The Bayou"/>
     <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="α -2 (-4 instead if you are at a Bayou location)β -2. If The Rougarou is in you location, reveal another token.γ Reveal another token. If you fail, until the end of the round, you cannot move.δ -4. If The Rougarou is at your location, it attacks you."/>
+    <property name="Text" value="α: -2 (-4 instead if you are at a Bayou location).&#10;β: -2. If The Rougarou is in you location, reveal another token.&#10;γ: Reveal another token. If you fail, until the end of the round, you cannot move.&#10;δ: -4. If The Rougarou is at your location, it attacks you."/>
     <alternate name="Curse of the Rougarou" type="B">
       <property name="Encounter Set" value="The Bayou"/>
       <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="α -3 (-6 instead if you are at a Bayou location)β -3. If The Rougarou is in you location, reveal another token.γ Reveal another token. If you fail, until the end of the round, you cannot move.δ -4. If The Rougarou is at your location or a connecting location, it attacks you."/>
+      <property name="Text" value="α: -3 (-6 instead if you are at a Bayou location).&#10;β: -3. If The Rougarou is in you location, reveal another token.&#10;γ: Reveal another token. If you fail, until the end of the round, you cannot move.&#10;δ: -4. If The Rougarou is at your location or a connecting location, it attacks you."/>
     </alternate>
   </card>
   <card id="885f651f-7908-4f6f-8f55-2809536804e5" name="A Creature of the Bayou" size="HorizCard">
@@ -140,15 +140,14 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
-    <property name="Traits" value="New Orleans"/>
-    <alternate name="New Orleans" size="EncounterCard" type="B">
+    <property name="Traits" value="New Orleans."/>
+    <alternate name="Garden District" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Garden District"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="1"/>
       <property name="Clues" value="0"/>
       <property name="Doom" value=""/>
-      <property name="Traits" value="New Orleans"/>
+      <property name="Traits" value="New Orleans."/>
       <property name="Text" value="η: Test ί (7) to try to break into a nearby greenhouse and take a look around. If you succeed, remember that the investigators have &quot;found a strange doll.&quot;"/>
     </alternate>
   </card>
@@ -160,15 +159,14 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
-    <property name="Traits" value="New Orleans"/>
-    <alternate name="New Orleans" size="EncounterCard" type="B">
+    <property name="Traits" value="New Orleans."/>
+    <alternate name="Broadmoor" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Broadmoor"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="3"/>
       <property name="Clues" value="1π"/>
       <property name="Doom" value=""/>
-      <property name="Traits" value="New Orleans"/>
+      <property name="Traits" value="New Orleans."/>
       <property name="Text" value="η: Resign. &quot;We can't catch the beast!&quot; You make your way to safety, letting the beast roam free."/>
     </alternate>
   </card>
@@ -199,16 +197,15 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
-    <property name="Traits" value="Riverside"/>
-    <alternate name="Riverside" size="EncounterCard" type="B">
+    <property name="Traits" value="Riverside."/>
+    <alternate name="Audubon Park" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Audubon Park"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="3"/>
       <property name="Clues" value="1π"/>
       <property name="Doom" value=""/>
       <property name="Victory Points" value="1"/>
-      <property name="Traits" value="Riverside"/>
+      <property name="Traits" value="Riverside."/>
       <property name="Text" value="Forced – When you evade an enemy at Audubon Park: Discard a random card from your hand."/>
     </alternate>
   </card>
@@ -220,15 +217,14 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
-    <property name="Traits" value="Riverside"/>
-    <alternate name="Riverside" size="EncounterCard" type="B">
+    <property name="Traits" value="Riverside."/>
+    <alternate name="Faubourg Marigny" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Faubourg Marigny"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="4"/>
       <property name="Clues" value="0"/>
       <property name="Doom" value=""/>
-      <property name="Traits" value="Riverside"/>
+      <property name="Traits" value="Riverside."/>
       <property name="Text" value="While you are at Fauborg Marigny, reduce the cost of each asset you play by 1.η : Resign. &quot;We can't catch the beast!&quot; You make your way to safety, letting the beast roam free."/>
     </alternate>
   </card>
@@ -260,9 +256,8 @@
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
     <property name="Traits" value="Wilderness."/>
-    <alternate name="Wilderness" size="EncounterCard" type="B">
+    <alternate name="Trapper's Cabin" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Trapper's Cabin"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="3"/>
       <property name="Clues" value="0"/>
@@ -280,9 +275,8 @@
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
     <property name="Traits" value="Wilderness."/>
-    <alternate name="Wilderness" size="EncounterCard" type="B">
+    <alternate name="Twisted Underbrush" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Twisted Underbrush"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="3"/>
       <property name="Clues" value="1π"/>
@@ -320,9 +314,8 @@
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
     <property name="Traits" value="Unhallowed."/>
-    <alternate name="Unhallowed Land" size="EncounterCard" type="B">
+    <alternate name="Ritual Grounds" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Ritual Grounds"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="2"/>
       <property name="Clues" value="1π"/>
@@ -341,9 +334,8 @@
     <property name="Clues" value=""/>
     <property name="Doom" value=""/>
     <property name="Traits" value="Unhallowed."/>
-    <alternate name="Unhallowed Land" size="EncounterCard" type="B">
+    <alternate name="Overgrown Cairns" size="EncounterCard" type="B">
       <property name="Encounter Set" value="The Bayou"/>
-      <property name="Subtitle" value="Overgrown Cairns"/>
       <property name="Type" value="Location"/>
       <property name="Shroud" value="4"/>
       <property name="Clues" value="0"/>
@@ -356,6 +348,7 @@
   <card id="2046ee30-8aa0-41b8-a824-11525fcb94ad" name="Lady Esprit">
     <property name="Card Number" value="19"/>
     <property name="Quantity" value="1"/>
+    <property name="Subtitle" value="Dangerous Bokor"/>
     <property name="Encounter Set" value="The Bayou"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Asset"/>
@@ -364,7 +357,7 @@
     <property name="Damage" value="2"/>
     <property name="Skill Icons" value="ά έ ΰ"/>
     <property name="Slot" value="Ally"/>
-    <property name="Traits" value="Ally. Sorcerer. "/>
+    <property name="Traits" value="Ally. Sorcerer."/>
     <property name="Text" value="η Exhaust Lady Esprit and deal her 1 horror: Heal 2 damage or gain 2 resources. Any investigator at Lady Esprit's location may activate this ability."/>
   </card>
   <card id="7f80ca4a-7027-485a-bb47-0d795339131e" name="Bear Trap">
@@ -445,6 +438,7 @@
   <card id="ed7463fc-09bf-4cfd-a9e1-e8d7440dd669" name="The Rougarou" size="EncounterCard">
     <property name="Card Number" value="28"/>
     <property name="Quantity" value="1"/>
+    <property name="Subtitle" value="Cursed Soul"/>
     <property name="Encounter Set" value="Curse of the Rougarou"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Enemy"/>
@@ -453,7 +447,7 @@
     <property name="Health" value="5π"/>
     <property name="Sanity" value="2"/>
     <property name="Damage" value="2"/>
-    <property name="Traits" value="Monster. Creature. Elite. "/>
+    <property name="Traits" value="Monster. Creature. Elite."/>
     <property name="Keywords" value="Aloof. Retaliate."/>
     <property name="Text" value="As an additional cost for an investigator to engage The Rougarou, the investigators must spend 1 clue, as a group (2 clues instead if there are 3 or 4 investigators).Forced – After The Rougarou takes 1 π  damage during a single phase: Find the location that is farthest from all investigator. Move The Rougarou (one location at a time) until it enters that location."/>
   </card>
@@ -486,7 +480,7 @@
     <property name="Health" value="3"/>
     <property name="Sanity" value="1"/>
     <property name="Damage" value="1"/>
-    <property name="Traits" value=" Monster. Dhole. "/>
+    <property name="Traits" value="Monster. Dhole."/>
     <property name="Keywords" value="Spawn – Any non-Bayou location.Prey – Lowest remaining health.Hunter."/>
     <property name="Text" value="Forced – When Slime-Covered Dhole enters a location: Each investigator at that location takes 1 horror."/>
   </card>
@@ -500,7 +494,7 @@
     <property name="Health" value="4"/>
     <property name="Sanity" value="1"/>
     <property name="Damage" value="2"/>
-    <property name="Traits" value=" Monster. Gug. "/>
+    <property name="Traits" value="Monster. Gug."/>
     <property name="Keywords" value="Spawn – Any Bayou location.Hunter."/>
   </card>
   <card id="8c355925-69bd-4250-bae7-c7a8207e19a0" name="Dark Young Host" size="EncounterCard">
@@ -514,7 +508,7 @@
     <property name="Sanity" value="2"/>
     <property name="Damage" value="2"/>
     <property name="Victory Points" value="1"/>
-    <property name="Traits" value=" Monster. Dark Young. "/>
+    <property name="Traits" value="Monster. Dark Young."/>
     <property name="Keywords" value="Spawn – Any Bayou location."/>
     <property name="Text" value="Forced – When 1 or more clues are placed on Dark Young Host's location: Place those clues on Dark Young Host.Forced – When Dark Young Host is defeated: Move all clues on Dark Young Host to its location."/>
   </card>

--- a/o8g/Sets/Dark Side of the Moon/set.xml
+++ b/o8g/Sets/Dark Side of the Moon/set.xml
@@ -126,12 +126,12 @@
       <property name="Card Number" value="206" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="Dark Side of the Moon" />
-      <property name="Subtitle" value="EASY/STANDARD" />
+      <property name="Subtitle" value="EASY / STANDARD" />
       <property name="Type" value="Scenario" />
       <property name="Text" value="α: –X. X is half your alarm level (rounded up).&#10;β: Reveal another token. If you fail and your alarm level is higher than your modified skill value, after this skill test ends, draw the top card of the encounter deck.&#10;γ: –1. If you fail, raise your alarm level by 1.&#10;δ: +1. The black cat summons several other cats to help. If this token is revealed during an evasion attempt and you succeed, deal 2 damage to the evaded enemy." />
       <alternate name="Dark Side of the Moon" type="B" size="EncounterCard">
         <property name="Encounter Set" value="Dark Side of the Moon" />
-        <property name="Subtitle" value="HARD/EXPERT" />
+        <property name="Subtitle" value="HARD / EXPERT" />
         <property name="Type" value="Scenario" />
         <property name="Text" value="α: –X. X is your alarm level.&#10;β: Reveal another token. If you fail and your alarm level is higher than your modified skill value, after this skill test ends, draw the top card of the encounter deck.&#10;γ: –2. If you fail, raise your alarm level by 1.&#10;δ: 0. The black cat summons several other cats to help. If this token is revealed during an evasion attempt and you succeed, deal 2 damage to the evaded enemy." />
       </alternate>

--- a/o8g/Sets/Dim Carcosa/set.xml
+++ b/o8g/Sets/Dim Carcosa/set.xml
@@ -158,13 +158,15 @@
     <property name="Card Number" value="316"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Dim Carcosa"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;α: -2 (-4 instead if you have no sanity remaining).&#10;β: Reveal another token. If you fail, take 1 horror.&#10;γ: -3. If you fail and Hastur is in play, place 1 clue on your location (from the token bank).&#10;δ: -3. If this token is revealed during an attack or evasion attempt against a Monster or Ancient One enemy, lose 1 action."/>
+    <property name="Text" value="α: -2 (-4 instead if you have no sanity remaining).&#10;β: Reveal another token. If you fail, take 1 horror.&#10;γ: -3. If you fail and Hastur is in play, place 1 clue on your location (from the token bank).&#10;δ: -3. If this token is revealed during an attack or evasion attempt against a Monster or Ancient One enemy, lose 1 action."/>
     <alternate name="Dim Carcosa" type="B">
       <property name="Encounter Set" value="Dim Carcosa"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value=" Hard / Expert &#10;α: -X. X is the amount of horror on you.&#10;β: Reveal another token. If you fail, take 2 horror.&#10;γ: -5. If you fail and Hastur is in play, place 1 clue on your location (from the token bank).&#10;δ: -5. If this token is revealed during an attack or evasion attempt against a Monster or Ancient One enemy, lose 1 action."/>
+      <property name="Text" value="α: -X. X is the amount of horror on you.&#10;β: Reveal another token. If you fail, take 2 horror.&#10;γ: -5. If you fail and Hastur is in play, place 1 clue on your location (from the token bank).&#10;δ: -5. If this token is revealed during an attack or evasion attempt against a Monster or Ancient One enemy, lose 1 action."/>
     </alternate>
   </card>
   <card id="58c35bbb-2bee-4931-a1e3-0d56ece7f152" name="Madness Coils" size="HorizCard">

--- a/o8g/Sets/Dunwich Legacy/set.xml
+++ b/o8g/Sets/Dunwich Legacy/set.xml
@@ -557,12 +557,14 @@
     <property name="Card Number" value="41"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Extracurricular Activity"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="Easy / Standard&#10;α: -1. If you fail, discard the top 3 cards of your deck.&#10;β: -1 (-3 instead if there are 10 or more cards in your discard pile).&#10;δ: -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards."/>
+    <property name="Text" value="α: -1. If you fail, discard the top 3 cards of your deck.&#10;β: -1 (-3 instead if there are 10 or more cards in your discard pile).&#10;δ: -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards."/>
     <alternate name="Extracurricular Activity" type="B">
       <property name="Encounter Set" value="Extracurricular Activity"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="Hard / Expert&#10;α: -2. If you fail, discard the top 5 cards of your deck.&#10;β: -1 (-5 instead if there are 10 or more cards in your discard pile).&#10;δ: -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."/>
+      <property name="Text" value="α: -2. If you fail, discard the top 5 cards of your deck.&#10;β: -1 (-5 instead if there are 10 or more cards in your discard pile).&#10;δ: -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."/>
     </alternate>
   </card>
   <card id="6566fbf5-5332-4710-b25d-732161ecfb55" name="Quiet Halls" size="HorizCard">
@@ -574,7 +576,7 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value=""/>
     <property name="Doom" value="7"/>
-    <alternate name="Quiet Halls" size="HorizCard" type="B">
+    <alternate name="Something Stirs" size="HorizCard" type="B">
       <property name="Encounter Set" value="Extracurricular Activity"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="1"/>
@@ -594,7 +596,7 @@
     <property name="Clues" value=""/>
     <property name="Doom" value="3"/>
     <property name="Text" value="Each investigator's maximum hand size is reduced by 3 while checking his or her hand size during the upkeep phase."/>
-    <alternate name="Dead of Night" size="HorizCard" type="B">
+    <alternate name="An Experiment Gone Wrong" size="HorizCard" type="B">
       <property name="Encounter Set" value="Extracurricular Activity"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="2"/>
@@ -614,7 +616,7 @@
     <property name="Clues" value=""/>
     <property name="Doom" value="2"/>
     <property name="Text" value="Forced - When this agenda would advance by reaching its doom threshold: Instead, remove all doom in play and move The Experiment 1 location toward the Dormitories.&#10;Objective - If The Experiment enters the Dormitories, advance."/>
-    <alternate name="The Beast Unleashed" size="HorizCard" type="B">
+    <alternate name="Not Fast Enough" size="HorizCard" type="B">
       <property name="Encounter Set" value="Extracurricular Activity"/>
       <property name="Type" value="Agenda"/>
       <property name="Level" value="3"/>
@@ -633,7 +635,7 @@
     <property name="Shroud" value=""/>
     <property name="Clues" value="3π "/>
     <property name="Doom" value=""/>
-    <alternate name="After Hours" size="HorizCard" type="B">
+    <alternate name="The Head Janitor" size="HorizCard" type="B">
       <property name="Encounter Set" value="Extracurricular Activity"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="1"/>
@@ -653,7 +655,7 @@
     <property name="Clues" value="0"/>
     <property name="Doom" value=""/>
     <property name="Text" value="η Spend 1 clue: Discard the top 5 cards of the encounter deck (top 10 instead if there is only 1 player in the game).&#10;Forced - If you discard &quot;Jazz&quot; Mulligan for any reason, resolve his revelation effect.&#10;Objective - When you take control of &quot;Jazz&quot; Mulligan, advance."/>
-    <alternate name="Rice's Whereabouts" size="HorizCard" type="B">
+    <alternate name="The Experiment Is Loose!" size="HorizCard" type="B">
       <property name="Encounter Set" value="Extracurricular Activity"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="2"/>
@@ -673,7 +675,7 @@
     <property name="Clues" value="0"/>
     <property name="Doom" value=""/>
     <property name="Text" value="Objective - Find and complete an objective on another encounter card."/>
-    <alternate name="Campus Safety" size="HorizCard" type="B">
+    <alternate name="The Beast's Death" size="HorizCard" type="B">
       <property name="Encounter Set" value="Extracurricular Activity"/>
       <property name="Type" value="Act"/>
       <property name="Level" value="3"/>
@@ -940,12 +942,14 @@
     <property name="Card Number" value="62"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The House Always Wins"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="Easy / Standard&#10;α: -2. You may spend 2 resources to treat this token as a 0, instead.&#10;β: -3. If you succeed, gain 3 resources.&#10;γ: -2. If you fail, discard 3 resources."/>
+    <property name="Text" value="α: -2. You may spend 2 resources to treat this token as a 0, instead.&#10;β: -3. If you succeed, gain 3 resources.&#10;γ: -2. If you fail, discard 3 resources."/>
     <alternate name="The House Always Wins" type="B">
       <property name="Encounter Set" value="The House Always Wins"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="Hard / Expert&#10;α: -3. You may spend 3 resources to treat this token as a 0, instead.&#10;β: -3. If you fail, discard 3 resources.&#10;γ: -2. Discard 3 resources."/>
+      <property name="Text" value="α: -3. You may spend 3 resources to treat this token as a 0, instead.&#10;β: -3. If you fail, discard 3 resources.&#10;γ: -2. Discard 3 resources."/>
     </alternate>
   </card>
   <card id="f6a860e8-64e9-495a-8ce3-4841f83f0f47" name="The Clover Club" size="HorizCard">

--- a/o8g/Sets/Echoes of the Past/set.xml
+++ b/o8g/Sets/Echoes of the Past/set.xml
@@ -187,12 +187,14 @@
     <property name="Card Number" value="120"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Echoes of the Past"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="Easy / Standard&#10;α: -X. X is the highest number of doom on an enemy in play.&#10;β: -2. If you fail, place 1 doom on the nearest enemy.&#10;γ: -2. If you fail, discard a random card from your hand.&#10;δ: -2. If you fail and there is an enemy at your location, take 1 horror."/>
+    <property name="Text" value="α: -X. X is the highest number of doom on an enemy in play.&#10;β: -2. If you fail, place 1 doom on the nearest enemy.&#10;γ: -2. If you fail, discard a random card from your hand.&#10;δ: -2. If you fail and there is an enemy at your location, take 1 horror."/>
     <alternate name="Echoes of the Past" type="B">
       <property name="Encounter Set" value="Echoes of the Past"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value=" Hard / Expert &#10;α: -X. X is the total number of doom on enemies in play.&#10;β: -4. Place 1 doom on the nearest enemy.&#10;γ: -4. Discard a random card from your hand.&#10;δ: -4. If there is an enemy at your location, take 1 horror."/>
+      <property name="Text" value="α: -X. X is the total number of doom on enemies in play.&#10;β: -4. Place 1 doom on the nearest enemy.&#10;γ: -4. Discard a random card from your hand.&#10;δ: -4. If there is an enemy at your location, take 1 horror."/>
     </alternate>
   </card>
   <card id="db645ddc-72b0-4ada-9e05-49bcae6f85a5" name="The Truth is Hidden" size="HorizCard">

--- a/o8g/Sets/For the Greater Good/set.xml
+++ b/o8g/Sets/For the Greater Good/set.xml
@@ -162,6 +162,7 @@
     <card id="22e3ab3a-027d-4f4a-9a84-94e076bbc62f" name="The Council’s Coffer">
       <property name="Card Number" value="196" />
       <property name="Quantity" value="2" />
+      <property name="Subtitle" value="What’s in the Box?"/>
       <property name="Type" value="Asset" />
       <property name="Traits" value="Item. Relic." />
       <property name="Text" value="Uses (1π locks).&#10;If there are no locks on The Council’s Coffer, each investigator searches his or her deck or discard pile for any card and immediately plays it at no cost. Exile The Council’s Coffer. (Max once per campaign.)&#10;η η: Test any skill (5). If you succeed, remove 1 lock. Any investigator at your location may activate this ability.&#10;Card design by The Council at Arkham Nights 2017." />
@@ -179,11 +180,12 @@
       <property name="Card Number" value="197" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="For the Greater Good" />
+      <property name="Subtitle" value="EASY / STANDARD"/>
       <property name="Type" value="Scenario" />
       <property name="Text" value="α: –X. X is the highest number of doom on a Cultist enemy in play.&#10;β: –2. Reveal another token.&#10;γ: –3. If you fail, place 1 doom on the nearest Cultist enemy.&#10;δ: –3. If you fail, move 1 doom from the nearest Cultist enemy to the current agenda." />
-      <property name="Level" value="1" />
       <alternate name="For the Greater Good" size="EncounterCard" type="B">
         <property name="Encounter Set" value="For the Greater Good" />
+        <property name="Subtitle" value="HARD / EXPERT"/>
         <property name="Type" value="Scenario" />
         <property name="Text" value="α: –X. X is the total number of doom among Cultist enemies in play.&#10;β: –2. Reveal another token.&#10;γ: –3. If you fail, place 1 doom on each Cultist enemy in play. If there are no Cultist enemies in play, reveal another token.&#10;δ: –3. If you fail, move all doom from the Cultist enemy with the most doom on it to the current agenda. If no Cultist enemies in play have doom on them, reveal another token." />
         <property name="Level" value="1" />

--- a/o8g/Sets/Guardians of the Abyss/set.xml
+++ b/o8g/Sets/Guardians of the Abyss/set.xml
@@ -7,12 +7,12 @@
       <property name="Encounter Set" value="The Eternal Slumber" />
       <property name="Subtitle" value="EASY / STANDARD" />
       <property name="Type" value="Scenario" />
-      <property name="Text" value="α: –X. X is the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.γ: 0. For this skill test, ignore any effect that would increase your skill value.δ: –5. You may add 1 strength to the abyss to automatically succeed, instead.Strength of the Abyss:" />
+      <property name="Text" value="α: –X. X is the strength of the abyss.&#10;β: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.&#10;γ: 0. For this skill test, ignore any effect that would increase your skill value.&#10;δ: –5. You may add 1 strength to the abyss to automatically succeed, instead.&#10;Strength of the Abyss:" />
       <alternate name="The Eternal Slumber" size="EncounterCard" type="B">
         <property name="Encounter Set" value="The Eternal Slumber" />
         <property name="Subtitle" value="HARD / EXPERT" />
         <property name="Type" value="Scenario" />
-        <property name="Text" value="α: –X. X is 1 more than the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.γ: –2. For this skill test, ignore any effect that would increase your skill value.δ: –6. You may add 1 strength to the abyss to automatically succeed, instead.Strength of the Abyss:" />
+        <property name="Text" value="α: –X. X is 1 more than the strength of the abyss.&#10;β: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.&#10;γ: –2. For this skill test, ignore any effect that would increase your skill value.&#10;δ: –6. You may add 1 strength to the abyss to automatically succeed, instead.&#10;Strength of the Abyss:" />
       </alternate>
     </card>
     <card id="c550a922-9c5f-4a6b-bab7-57c6726716fd" name="Jessie’s Request" size="HorizCard">
@@ -35,7 +35,7 @@
       <property name="Type" value="Agenda" />
       <property name="Text" value="Forced – If the strength of the abyss is 0: Set the strength of the abyss to 1. Each investigator draws 1 card and heals 1 horror." />
       <property name="Doom" value="6" />
-      <alternate name="The Abyss Grows..." size="HorizCard" type="B">
+      <alternate name="The Abyss Grows…" size="HorizCard" type="B">
         <property name="Encounter Set" value="The Eternal Slumber" />
         <property name="Type" value="Agenda" />
         <property name="Text" value="As more and more fall victim to the curse that has infected Cairo, a silent terror grips the city. When night falls again, the streets are filled with a sudden panic. It starts with turmoil outside the hospital, as people demand to know what has happened to their loved ones and what the doctors are doing to solve the problem. Before long, rioting and looting erupt throughout the city. By midnight, the streets have descended into utter chaos.Shuffle the encounter discard pile into the encounter deck.Add 1 strength to the abyss." />
@@ -212,15 +212,17 @@
       <property name="Card Number" value="16" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="The Night’s Usurper" />
+      <property name="Subtitle" value="EASY / STANDARD" />
       <property name="Type" value="Scenario" />
-      <property name="Text" value="α: –X. X is the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.γ: –1. For this skill test, ignore any effect that would increase your skill value.δ: –4. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss.Strength of the Abyss:" />
+      <property name="Text" value="α: –X. X is the strength of the abyss.&#10;β: Reveal another token. If you fail and the strength of the abyss is 3 or lower, add 1 strength to the abyss.&#10;γ: –1. For this skill test, ignore any effect that would increase your skill value.&#10;δ: –4. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss.Strength of the Abyss:" />
       <alternate name="The Night’s Usurper" size="EncounterCard" type="B">
         <property name="Encounter Set" value="The Night’s Usurper" />
+        <property name="Subtitle" value="HARD / EXPERT" />
         <property name="Type" value="Scenario" />
-        <property name="Text" value="α: –X. X is 1 more than the strength of the abyss.β: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.γ: –3. For this skill test, ignore any effect that would increase your skill value.δ: –5. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss.Strength of the Abyss:" />
+        <property name="Text" value="α: –X. X is 1 more than the strength of the abyss.&#10;β: Reveal another token. If you fail and the strength of the abyss is 5 or lower, add 1 strength to the abyss.&#10;γ: –3. For this skill test, ignore any effect that would increase your skill value.&#10;δ: –5. If you succeed and the strength of the abyss is 4 or more, remove 1 strength from the abyss.Strength of the Abyss:" />
       </alternate>
     </card>
-    <card id="74e12e40-655d-4475-b829-3d2feae1b6a5" name="The Brotherhood Bides Their Time" size="HorizCard">
+    <card id="74e12e40-655d-4475-b829-3d2feae1b6a5" name="The Brotherhood Bides Their Time" size="HorizCard">
       <property name="Card Number" value="17" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="The Night’s Usurper" />
@@ -426,6 +428,7 @@
     <card id="586f9776-c2f6-468b-afff-63b625902eae" name="Dr. Layla El Masri" size="EncounterCard">
       <property name="Card Number" value="31" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Hieratic Translator"/>
       <property name="Encounter Set" value="Brotherhood of the Beast" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
@@ -447,6 +450,7 @@
     <card id="24eef006-8861-42ea-aa67-950288e1e1de" name="Dr. Wentworth Moore" size="EncounterCard">
       <property name="Card Number" value="32" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Dark Supplicant"/>
       <property name="Encounter Set" value="Brotherhood of the Beast" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
@@ -469,6 +473,7 @@
     <card id="76f6e377-7192-4ed6-81a7-6c8852090f8f" name="Nadia Nimr" size="EncounterCard">
       <property name="Card Number" value="33" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Priestess of the Beast"/>
       <property name="Encounter Set" value="Brotherhood of the Beast" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
@@ -490,6 +495,7 @@
     <card id="01a1356f-be9c-4cf2-94f8-544baa853d9f" name="Farid" size="EncounterCard">
       <property name="Card Number" value="34" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Seedy Salesman"/>
       <property name="Encounter Set" value="Brotherhood of the Beast" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
@@ -511,6 +517,7 @@
     <card id="8728bd85-572a-4ec9-b518-6e2676f267eb" name="Nassor" size="EncounterCard">
       <property name="Card Number" value="35" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Brotherhood Operative"/>
       <property name="Encounter Set" value="Brotherhood of the Beast" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Cultist. Brotherhood." />
@@ -531,6 +538,7 @@
     <card id="9ebacd6c-7f37-4051-98ea-530141d18e30" name="Professor Nathaniel Taylor" size="EncounterCard">
       <property name="Card Number" value="36" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Keeper of Antiquities"/>
       <property name="Encounter Set" value="Brotherhood of the Beast" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Cultist. Brotherhood." />

--- a/o8g/Sets/Harvey Walters/set.xml
+++ b/o8g/Sets/Harvey Walters/set.xml
@@ -166,7 +166,7 @@
     <card id="ce98b3de-2197-4c8c-bdc2-327729a87842" name="Whitton Greene">
       <property name="Card Number" value="13" />
       <property name="Quantity" value="2" />
-      <property name="Subtitle" value="Hunter or Rare Books" />
+      <property name="Subtitle" value="Hunter of Rare Books" />
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ally. Miskatonic." />
       <property name="Text" value="While you control a Tome or Relic asset, you get +1 έ.&#10;ι After you reveal a location or put a new location into play, exhaust Whitton Greene: Search the top 6 cards of your deck for a Tome or Relic asset and draw it. Shuffle you deck." />
@@ -337,7 +337,7 @@
       <property name="Combat" value="1" />
       <property name="Skill Icons" value="" />
     </card>
-    <card id="aa4aef04-a7e7-4021-809f-07c1b512dda1" name="Mind Over Matter">
+    <card id="aa4aef04-a7e7-4021-809f-07c1b512dda1" name="Mind over Matter">
       <property name="Card Number" value="26" />
       <property name="Quantity" value="2" />
       <property name="Type" value="Event" />

--- a/o8g/Sets/Heart of the Elders/set.xml
+++ b/o8g/Sets/Heart of the Elders/set.xml
@@ -174,11 +174,13 @@
     <property name="Card Number" value="205"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Heart of the Elders"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
     <property name="Text" value="α: -1 (-3 instead if you are in a [[cave]] location).&#10;β: -2. If you fail, place 1 doom on your location.&#10;γ: -2. If you are poisoned, this test automatically fails instead.&#10;δ: -3. If you fail, take 1 horror."/>
     <alternate name="Heart of the Elders" type="B">
       <property name="Encounter Set" value="Heart of the Elders"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
       <property name="Text" value="α: -2 (-4 instead if you are in a [[cave]] location).&#10;β: -3. If you fail, place 1 doom on your location.&#10;γ: -3. If you are poisoned, this test automatically fails instead. If you are not poisoned and you fail, put a set-aside Poisoned weakness into play in your threat area.&#10;δ: -4. If you fail, take 1 horror."/>

--- a/o8g/Sets/Horror in High Gear/set.xml
+++ b/o8g/Sets/Horror in High Gear/set.xml
@@ -73,6 +73,7 @@
     <card id="b350b447-be92-4ad3-9c56-525453073f21" name="Tristan Botley">
       <property name="Card Number" value="194" />
       <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Fixer for Hire"/>
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ally. Criminal. Cursed." />
       <property name="Text" value="ι After your turn begins: Choose two skills. Until the start of your next turn, you get +1 to each of those skills.&#10;ι After any skill test ends in which a total of 3 or more [Curse] or [Bless] tokens were revealed: Play Tristan Botley from your hand, at no cost." />

--- a/o8g/Sets/In Too Deep/set.xml
+++ b/o8g/Sets/In Too Deep/set.xml
@@ -189,10 +189,12 @@
       <property name="Card Number" value="123" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="In Too Deep" />
+      <property name="Subtitle" value="EASY / STANDARD"/>
       <property name="Type" value="Scenario" />
       <property name="Text" value="α: –1 for each location to the east of your location (on the same row).&#10;β: –2. If you fail, move to the connecting location to the east, ignoring all barriers.&#10;γ: –3. If you fail, choose a connecting location with no barriers between it and your location. Place 1 barrier between the two locations.&#10;δ: –X. X is the number of barriers between your location and all connecting locations." />
       <alternate name="In Too Deep" type="B" size="EncounterCard">
         <property name="Encounter Set" value="In Too Deep" />
+        <property name="Subtitle" value="HARD / EXPERT"/>
         <property name="Type" value="Scenario" />
         <property name="Text" value="α: –2 for each location to the east of your location (on the same row).&#10;β: –4. If you fail, move to the connecting location to the east, ignoring all barriers.&#10;γ: –5. If you fail, choose a connecting location with no barriers between it and your location. Place 1 barrier between the two locations.&#10;δ: –X. X is twice the number of barriers between your location and all connecting locations." />
       </alternate>

--- a/o8g/Sets/In the Clutches of Chaos/set.xml
+++ b/o8g/Sets/In the Clutches of Chaos/set.xml
@@ -161,6 +161,7 @@
     <card id="6d30fb09-a286-44e7-b504-267493c4704a" name="Anna Kaslow">
       <property name="Card Number" value="283" />
       <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Mysterious Soothsayer"/>
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ally. Clairvoyant." />
       <property name="Text" value="You have 2 additional tarot slots.&#10;ι When the game begins, if Anna Kaslow is in your opening hand: Put her into play.&#10;ι After Anna Kaslow enters play: Search your deck for a Tarot asset and put it into play." />
@@ -180,10 +181,12 @@
       <property name="Card Number" value="284" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="In the Clutches of Chaos" />
+      <property name="Subtitle" value="EASY / STANDARD"/>
       <property name="Type" value="Scenario" />
       <property name="Text" value="α: –X. X is the total amount of doom and breaches on your location.&#10;β: Reveal another token. If there are fewer than 3 breaches on your location, place 1 breach on your location.&#10;γ: –2. For each point you fail by, remove 1 breach from the current act.&#10;δ: –3. If you fail, place 1 breach on a random location." />
       <alternate name="In the Clutches of Chaos" size="EncounterCard" type="B">
         <property name="Encounter Set" value="In the Clutches of Chaos" />
+        <property name="Subtitle" value="HARD / EXPERT"/>
         <property name="Type" value="Scenario" />
         <property name="Text" value="α: –X. X is 1 higher than the total amount of doom and breaches on your location.&#10;β: Reveal another token. If there are fewer than 3 breaches on your location, place 1 breach on your location.&#10;γ: –3. For each point you fail by, remove 1 breach from the current act.&#10;δ: –4. If you fail, place 1 breach on a random location." />
       </alternate>

--- a/o8g/Sets/Into the Maelstrom/set.xml
+++ b/o8g/Sets/Into the Maelstrom/set.xml
@@ -78,7 +78,7 @@
     <card id="ed9fa0a4-4333-4cc2-9317-2daf67dd3e08" name="Lucky Dice">
       <property name="Card Number" value="307" />
       <property name="Quantity" value="1" />
-      <property name="Subtitle" value="... Or Are They?" />
+      <property name="Subtitle" value="…Or Are They?" />
       <property name="Type" value="Asset" />
       <property name="Traits" value="Item. Relic." />
       <property name="Text" value="Exceptional.&#10;ι When you reveal a  non-[Curse], non-[Autofail] chaos token, add 1 [Curse] token to the chaos bag: Ignore the just revealed token and reveal another one to resolve. If that token as a [Curse] or [Autofail] symbol, return Lucky Dice to your hand (cannot be ignored/canceled)." />
@@ -398,12 +398,12 @@
       <property name="Card Number" value="328" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="Into the Maelstrom" />
-      <property name="Subtitle" value="Santuary of Father Dagon" />
+      <property name="Subtitle" value="Sanctuary of Father Dagon" />
       <property name="Type" value="Location" />
       <property name="Traits" value="Y'ha-nthlei. Lair." />
       <alternate name="Lair of Dagon" type="B" size="EncounterCard">
         <property name="Encounter Set" value="Into the Maelstrom" />
-        <property name="Subtitle" value="Santuary of Father Dagon" />
+        <property name="Subtitle" value="Sanctuary of Father Dagon" />
         <property name="Type" value="Location" />
         <property name="Traits" value="Y'ha-nthlei. Lair." />
         <property name="Text" value="Lair of Dagon gets –1 shroud for each Sanctum location with a key on it.&#10;θ Check Campaign Log. If all 7 keys are on locations and the Order's ritual was disrupted: You dig deep into your memories to recall what happened the last time you were here. Read Flash back XIV in the Campaign Guide." />

--- a/o8g/Sets/Lost in Time and Space/set.xml
+++ b/o8g/Sets/Lost in Time and Space/set.xml
@@ -172,13 +172,15 @@
     <property name="Card Number" value="311"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Lost in Time and Space"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="Easy / Standard&#10;α -1 for each Extradimensional location in play (max -5).&#10;β Reveal another token. If you fail, after this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.&#10;γ -3. If Yog-Sothoth is in play, it attacks you after this skill test.&#10;δ -X. X is the shroud value of your location. If you fail and your location is Extradimensional, discard it."/>
+    <property name="Text" value="α: -1 for each Extradimensional location in play (max -5).&#10;β: Reveal another token. If you fail, after this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.&#10;γ: -3. If Yog-Sothoth is in play, it attacks you after this skill test.&#10;δ: -X. X is the shroud value of your location. If you fail and your location is Extradimensional, discard it."/>
     <alternate name="Lost in Time and Space" type="B">
       <property name="Encounter Set" value="Lost in Time and Space"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;α -1 for each Extradimensional location in play.&#10;β Reveal another token. After this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.&#10;γ -5. If Yog-Sothoth is in play, it attacks you after this skill test.&#10;δ -X. X is twice the shroud value of your location. If you fail and your location is Extradimensional, discard it."/>
+      <property name="Text" value="α: -1 for each Extradimensional location in play.&#10;β: Reveal another token. After this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.&#10;γ: -5. If Yog-Sothoth is in play, it attacks you after this skill test.&#10;δ: -X. X is twice the shroud value of your location. If you fail and your location is Extradimensional, discard it."/>
     </alternate>
   </card>
   <card id="ee40c4bb-7167-413a-9f74-f90314347767" name="All is One" size="HorizCard">

--- a/o8g/Sets/Point of No Return/set.xml
+++ b/o8g/Sets/Point of No Return/set.xml
@@ -148,7 +148,7 @@
     <card id="eaa8acfd-c17a-4f69-b742-3afeb06daa25" name="Empower Self">
       <property name="Card Number" value="243" />
       <property name="Quantity" value="1" />
-      <property name="Subtitle" value="Accuity" />
+      <property name="Subtitle" value="Acuity" />
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ritual." />
       <property name="Text" value="Myriad. Limit 1 Empower Self (Acuity) per deck.&#10;Up to 3 Empower Self cards take up a single arcane slot.&#10;Anytime a card effect requires you to use ά instead of έ, you may ignore that aspect of the effect.&#10;θ Exhaust Empower Self: You get +2 έ for this test." />

--- a/o8g/Sets/Promo/set.xml
+++ b/o8g/Sets/Promo/set.xml
@@ -4,7 +4,6 @@
   <card id="08864675-f455-40db-8dac-70f0887dc648" name="Marie Lambeau" size="InvestigatorCard">
     <property name="Card Number" value="1"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Promo"/>
     <property name="Subtitle" value="The Entertainer"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Investigator"/>
@@ -18,17 +17,16 @@
     <property name="Traits" value="Performer. Sorcerer."/>
     <property name="Text" value="While you have 1 or more doom among cards you control, you may take an additional action during your turn, which can only be used to play Spell cards or activate Spell η abilities.&#10;ε effect: +1. You may add 1 doom to or remove 1 doom from a card you control."/>
     <alternate name="Marie Lambeau" size="InvestigatorCard" type="B">
-      <property name="Encounter Set" value="Promo"/>
       <property name="Subtitle" value="The Entertainer"/>
       <property name="Unique" value="ο"/>
       <property name="Type" value="Investigator"/>
       <property name="Class" value="mystic"/>
+      <property name="Text" value="Deck size: 30.&#10;Deckbuilding options: Spell cards level 0-5, Mystic cards (μ) level 0-3, Neutral cards level 0-5, Occult cards level 0, up to five other level 0 Seeker and/or Survivor cards (λ and/or ξ).&#10;Deckbuilding requirements (do not count toward deck size): Mystifying Song, Baron Samedi, 1 random basic weakness."/>
     </alternate>
   </card>
   <card id="13beb81c-4951-4891-9cb2-32d7c9c368bf" name="Mystifying Song">
     <property name="Card Number" value="2"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Promo"/>
     <property name="Type" value="Event"/>
     <property name="Class" value="Neutral"/>
     <property name="Cost" value="3"/>
@@ -39,7 +37,6 @@
   <card id="80aa551e-34a6-412c-8520-7f55a0526bdc" name="Baron Samedi">
     <property name="Card Number" value="3"/>
     <property name="Quantity" value="1"/>
-    <property name="Encounter Set" value="Promo"/>
     <property name="Subtitle" value="Lord of the Cemetery"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Asset"/>

--- a/o8g/Sets/Return to the Forgotten Age/set.xml
+++ b/o8g/Sets/Return to the Forgotten Age/set.xml
@@ -405,6 +405,7 @@
       <property name="Setup" value="2g" />
       <alternate name="Clinton Freeman" type="B">
         <property name="Encounter Set" value="Return to Threads of Fate" />
+        <property name="Subtitle" value="Should Have Stayed Home" />
         <property name="Type" value="Asset" />
         <property name="Traits" value="Bystander. Wayfarer." />
         <property name="Text" value="Revelation – Put Clinton Freeman into play at Velma’s Diner. Advance to Act 3g—“Discover the Truth.”&#10;η: Parley. Test ά or έ (3). If you succeed, place 1 clue on Clinton Freeman (from the token pool) and take 1 horror. If you fail, take 1 horror for each point you failed by." />
@@ -483,6 +484,7 @@
     <card id="fa371c67-b293-4735-9b77-631ec63ec006" name="Veda Whitsley">
       <property name="Card Number" value="37" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Skilled Botanist"/>
       <property name="Encounter Set" value="Return to Threads of Fate" />
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ally. Wayfarer." />

--- a/o8g/Sets/Return to the Path to Carcosa/set.xml
+++ b/o8g/Sets/Return to the Path to Carcosa/set.xml
@@ -50,6 +50,7 @@
     <card id="1971a1d6-9883-4e9a-ab34-f814c9414338" name="Archaic Glyphs">
       <property name="Card Number" value="4" />
       <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Markings of Isis" />
       <property name="Type" value="Asset" />
       <property name="Traits" value="Spell." />
       <property name="Text" value="You can only include this asset in your deck by upgrading it from Archaic Glyphs (Untranslated), and only if “you have translated the glyphs” in your Campaign Log.&#10;Uses (3 charges).&#10;η Spend 1 charge: Investigate. If you succeed, you may put an asset with printed cost of X or lower into play from your hand. X is the amount you succeeded by." />
@@ -230,7 +231,7 @@
       <property name="Subtitle" value="Act 2a" />
       <property name="Type" value="Act" />
       <property name="Text" value="Objective – When The Man in the Pallid Mask would be discarded from play, advance." />
-      <alternate name="Here's My Reply" size="HorizCard" type="B">
+      <alternate name="Here Is My Reply" size="HorizCard" type="B">
         <property name="Encounter Set" value="Return to Curtain Call" />
         <property name="Subtitle" value="Act 2b" />
         <property name="Type" value="Act" />
@@ -272,6 +273,7 @@
     <card id="128161fe-1d21-4a82-9c18-b633a2df44e5" name="La Comtesse" size="EncounterCard">
       <property name="Card Number" value="20" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Subverter of Plans" />
       <property name="Encounter Set" value="Return to Curtain Call" />
       <property name="Type" value="Enemy" />
       <property name="Traits" value="Humanoid. Servitor." />

--- a/o8g/Sets/Shattered Aeons/set.xml
+++ b/o8g/Sets/Shattered Aeons/set.xml
@@ -132,11 +132,13 @@
     <property name="Card Number" value="314"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Shattered Aeons"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="α: -1 (-4 instead if the Relic of Ages is at your location).&#10;β: -2. If you do not succeed by at least 1, place 1 doom on the nearest [β] enemy.&#10;γ: -2. If you are poisoned, this test automatically fails instead.&#10;δ: -2. If you fail, shuffle the topmost [[hex]] treachery in the encounter discard pile into the exploration deck."/>
+    <property name="Text" value="α: -1 (-4 instead if the Relic of Ages is at your location).&#10;β: -2. If you do not succeed by at least 1, place 1 doom on the nearest Cultist enemy.&#10;γ: -2. If you are poisoned, this test automatically fails instead.&#10;δ: -2. If you fail, shuffle the topmost [[Hex]] treachery in the encounter discard pile into the exploration deck."/>
     <alternate name="Shattered Aeons" type="B">
       <property name="Encounter Set" value="Shattered Aeons"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
       <property name="Text" value="α: -2 (-5 instead if the Relic of Ages is at your location).&#10;β: -3. Place 1 doom on each [β] enemy.&#10;γ: -3. If you are poisoned, this test automatically fails instead. If you are not poisoned and you fail, put a set-aside Poisoned weakness into play in your threat area.&#10;δ: -3. Shuffle the topmost [[hex]] treachery in the encounter discard pile into the exploration deck."/>
@@ -345,7 +347,7 @@
       <property name="Text" value="Forced - After you move from Nexus of N'kai to an [[Otherworld]] location, or vice versa: Take 1 horror for each clue on that [[Otherworld]] location.&#10;η: Explore. Draw the top card of the exploration deck. If it is a connecting location, put it into play and move to it. Do not take horror from the above Forced ability when moving via this effect."/>
     </alternate>
   </card>
-  <card id="74080182-a727-4a63-98b0-42e0909e4bdc" name="Ictaca" size="EncounterCard">
+  <card id="74080182-a727-4a63-98b0-42e0909e4bdc" name="Ichtaca" size="EncounterCard">
     <property name="Card Number" value="325"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Shattered Aeons"/>
@@ -597,11 +599,13 @@
     <property name="Card Number" value="344"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Turn Back Time"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
     <property name="Text" value="α: -X . X is the number of locations with doom on them.&#10;δ: -4. If you fail, place 1 doom on your location."/>
     <alternate name="Turn Back Time" type="B">
       <property name="Encounter Set" value="Turn Back Time"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
       <property name="Text" value="α: -X . X is the total amount of doom on locations.&#10;δ: -6. Place 1 doom on your location."/>

--- a/o8g/Sets/Stella Clark/set.xml
+++ b/o8g/Sets/Stella Clark/set.xml
@@ -350,7 +350,7 @@
       <property name="Unique" value="ο" />
       <property name="Skill Icons" value="" />
     </card>
-    <card id="566e4248-2ff8-4758-878c-a8f61a351e04" name="Lucky">
+    <card id="566e4248-2ff8-4758-878c-a8f61a351e04" name="Lucky!">
       <property name="Card Number" value="28" />
       <property name="Quantity" value="2" />
       <property name="Type" value="Event" />

--- a/o8g/Sets/The Blob That Ate Everything/set.xml
+++ b/o8g/Sets/The Blob That Ate Everything/set.xml
@@ -90,7 +90,7 @@
         <property name="Text" value="If this is the first time this act has advanced, read the following:&#10;—&#10;Regardless of how many times this act has advanced, read the following:&#10;Choose any Oozified location. Spawn the set-aside Vulnerable Heart enemy at the chosen location." />
       </alternate>
     </card>
-    <card id="87a2c12b-7f2f-4c24-8850-c508d1ec0861" name="Extra terrestrial Physiology" size="HorizCard">
+    <card id="87a2c12b-7f2f-4c24-8850-c508d1ec0861" name="Extraterrestrial Physiology" size="HorizCard">
       <property name="Card Number" value="7" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="The Blob That Ate Everything" />
@@ -320,7 +320,7 @@
         <property name="Encounter Set" value="Mi-Go Incursion" />
         <property name="Type" value="Story" />
         <property name="Traits" value="Part 2." />
-        <property name="Text" value="Read only if &quot;the sample was lost:&quot;&#10;Remove Mi-Go Harvester, Meteorite Sample, and this card from the game. Lose 2 countermeasures.&#10;—&#10;Read only if &quot;the sample was recovered:&quot;&#10;Put the set-aside Pet Oozling story asset into play under any investigator's control. Remove Meteorite Sample from the game. Add Mi-Go Harvester and this card to the victory display. Gain 2 countermeasures.&#10;Victory 1." />
+        <property name="Text" value="Read only if &quot;the sample was lost:&quot;&#10;Remove Mi-Go Harvester, Meteorite Sample, and this card from the game. Lose 2 countermeasures.&#10;—&#10;Read only if &quot;the sample was recovered:&quot;&#10;Put the set-aside Pet Oozeling story asset into play under any investigator's control. Remove Meteorite Sample from the game. Add Mi-Go Harvester and this card to the victory display. Gain 2 countermeasures.&#10;Victory 1." />
         <property name="Victory Points" value="1" />
       </alternate>
     </card>

--- a/o8g/Sets/The Boundary Beyond/set.xml
+++ b/o8g/Sets/The Boundary Beyond/set.xml
@@ -145,14 +145,16 @@
     <property name="Card Number" value="161"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Boundary Beyond"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;&#10;α: -1 (-3 instead if you are at an [[Ancient]] location).&#10;&#10;β: Reveal another token. If you fail, place 1 doom on a [[Cultist]] enemy.&#10;&#10;γ: Reveal another token. If you fail and there is a [[Serpent]] enemy at your location, it attacks you.&#10;&#10;δ: -4. If you fail, place 1 clue (from the token pool) on the nearest [[Ancient]] location."/>
+    <property name="Text" value="α: -1 (-3 instead if you are at an [[Ancient]] location).&#10;β: Reveal another token. If you fail, place 1 doom on a [[Cultist]] enemy.&#10;γ: Reveal another token. If you fail and there is a [[Serpent]] enemy at your location, it attacks you.&#10;δ: -4. If you fail, place 1 clue (from the token pool) on the nearest [[Ancient]] location."/>
     <alternate name="The Boundary Beyond" type="B">
       <property name="Encounter Set" value="The Boundary Beyond"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;&#10;α: -2 (-4 instead if you are at an [[Ancient]] location).&#10;&#10;β: Reveal another token. If you fail, place 1 doom on each [[Cultist]] enemy.&#10;&#10;γ: Reveal another token. If you fail, each [[Serpent]] enemy at your location attacks you.&#10;&#10;δ: -4. Place 1 clue (from the token pool) on the nearest [[Ancient]] location."/>
+      <property name="Text" value="α: -2 (-4 instead if you are at an [[Ancient]] location).&#10;β: Reveal another token. If you fail, place 1 doom on each [[Cultist]] enemy.&#10;γ: Reveal another token. If you fail, each [[Serpent]] enemy at your location attacks you.&#10;δ: -4. Place 1 clue (from the token pool) on the nearest [[Ancient]] location."/>
     </alternate>
   </card>
   <card id="3d3fd4fe-bfce-41ff-bcb3-9c8a258ad564" name="The Boundary, Broken" size="HorizCard">

--- a/o8g/Sets/The Circle Undone/set.xml
+++ b/o8g/Sets/The Circle Undone/set.xml
@@ -377,7 +377,7 @@
     <property name="Traits" value="Innate."/>
     <property name="Text" value="While you have 4 or more cards in hand, Curiosity gains ά έ (while you have 7 or more cards in hand, Curiosity gains ά ά έ έ, instead)."/>
   </card>
-  <card id="cb477972-7436-4bcc-81a9-1f3829ff1afb" name="Death XIII">
+  <card id="cb477972-7436-4bcc-81a9-1f3829ff1afb" name="Death · XIII">
     <property name="Card Number" value="27"/>
     <property name="Quantity" value="2"/>
     <property name="Subtitle" value="Free from the Past"/>
@@ -421,7 +421,7 @@
     <property name="Traits" value="Innate."/>
     <property name="Text" value="While you have 5 or more resources, Cunning gains έ ί (while you have 10 or more resources, Cunning gains έ έ ί ί, instead)."/>
   </card>
-  <card id="5979ffd1-1971-4802-abdd-c345fc60cb9c" name="The Moon XVIII">
+  <card id="5979ffd1-1971-4802-abdd-c345fc60cb9c" name="The Moon · XVIII">
     <property name="Card Number" value="31"/>
     <property name="Quantity" value="2"/>
     <property name="Subtitle" value="Message from Your Inner Self"/>
@@ -539,7 +539,7 @@
     <property name="Traits" value="Tarot."/>
     <property name="Text" value="θ During your turn, remove Ace of Rods from the game: You may take an additional action this turn, during which you get +2 to each of your skills.&#10;ι When the game begins, if Ace of Rods is in your opening hand: Put it into play."/>
   </card>
-  <card id="479a3456-8e6c-4df7-a778-dad99d0a0f9d" name="The Thirteenth Vision">
+  <card id="479a3456-8e6c-4df7-a778-dad99d0a0f9d" name="The 13th Vision">
     <property name="Card Number" value="41"/>
     <property name="Quantity" value="2"/>
     <property name="Type" value="Treachery"/>
@@ -548,7 +548,7 @@
     <property name="Traits" value="Omen."/>
     <property name="Text" value="Revelation - Put The 13th Vision into play in your threat area.&#10;Investigators at your location fail ties during skill tests.&#10;η η: Discard The 13th Vision."/>
   </card>
-  <card id="46163897-b6a8-4c6e-86ef-27c5eeb7f443" name="The Tower XVI">
+  <card id="46163897-b6a8-4c6e-86ef-27c5eeb7f443" name="The Tower · XVI">
     <property name="Card Number" value="42"/>
     <property name="Quantity" value="2"/>
     <property name="Subtitle" value="Circumstances Beyond Your Control"/>
@@ -564,17 +564,19 @@
     <property name="Card Number" value="43"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Disappearance at the Twilight Estate"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;α: -3. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location."/>
+    <property name="Text" value="α: -3. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location."/>
     <alternate name="Disappearance at the Twilight Estate" type="B">
       <property name="Encounter Set" value="Disappearance at the Twilight Estate"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;α: -5. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location."/>
+      <property name="Text" value="α: -5. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location."/>
     </alternate>
   </card>
-  <card id="9b434397-cb1c-4534-affb-efb27e8dbd66" name="JUDGEMENT XX" size="HorizCard">
+  <card id="9b434397-cb1c-4534-affb-efb27e8dbd66" name="JUDGEMENT · XX" size="HorizCard">
     <property name="Card Number" value="44"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Disappearance at the Twilight Estate"/>
@@ -726,17 +728,19 @@
     <property name="Card Number" value="50"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Witching Hour"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;α: -1. For each point you fail by, discard the top card of the encounter deck.&#10;γ: -1. If you fail, after this test resolves, draw the bottommost treachery in the encounter discard pile.&#10;δ: -3. If you fail, choose an exhausted or damaged Witch enemy at your location or at a connecting location. Ready that enemy and heal all damage from it."/>
+    <property name="Text" value="α: -1. For each point you fail by, discard the top card of the encounter deck.&#10;γ: -1. If you fail, after this test resolves, draw the bottommost treachery in the encounter discard pile.&#10;δ: -3. If you fail, choose an exhausted or damaged Witch enemy at your location or at a connecting location. Ready that enemy and heal all damage from it."/>
     <alternate name="The Witching Hour" type="B">
       <property name="Encounter Set" value="The Witching Hour"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;α: -2. Discard cards from the top of the encounter deck equal to this test's difficulty.&#10;γ: -2. If you fail, after this test resolves, draw the bottommost treachery in the encounter discard pile.&#10;δ: -4. If you fail, ready each Witch enemy at your location and at each connecting location. Heal all damage from each of those enemies."/>
+      <property name="Text" value="α: -2. Discard cards from the top of the encounter deck equal to this test's difficulty.&#10;γ: -2. If you fail, after this test resolves, draw the bottommost treachery in the encounter discard pile.&#10;δ: -4. If you fail, ready each Witch enemy at your location and at each connecting location. Heal all damage from each of those enemies."/>
     </alternate>
   </card>
-  <card id="8b6df157-2727-43c9-840f-d5db8b69f723" name="TEMPERANCE XIV" size="HorizCard">
+  <card id="8b6df157-2727-43c9-840f-d5db8b69f723" name="TEMPERANCE · XIV" size="HorizCard">
     <property name="Card Number" value="51"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Witching Hour"/>
@@ -1049,17 +1053,19 @@
     <property name="Card Number" value="65"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="At Death's Doorstep"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;α: -1 (-3 instead if your location is haunted).&#10;γ: -2. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location.&#10;δ: -2. If there is a Spectral enemy at your location, take 1 damage."/>
+    <property name="Text" value="α: -1 (-3 instead if your location is haunted).&#10;γ: -2. If you fail and this is an attack or evasion attempt, resolve each haunted ability on your location.&#10;δ: -2. If there is a Spectral enemy at your location, take 1 damage."/>
     <alternate name="At Death's Doorstep" type="B">
       <property name="Encounter Set" value="At Death's Doorstep"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;α: -2 (-4 instead if your location is haunted).&#10;γ: -3. If this is an attack or evasion attempt, resolve each haunted ability on your location.&#10;δ: -4. If there is a Spectral enemy at your location, take 1 damage and 1 horror."/>
+      <property name="Text" value="α: -2 (-4 instead if your location is haunted).&#10;γ: -3. If this is an attack or evasion attempt, resolve each haunted ability on your location.&#10;δ: -4. If there is a Spectral enemy at your location, take 1 damage and 1 horror."/>
     </alternate>
   </card>
-  <card id="f69b2d45-3917-4679-a48a-b6c32d47e874" name="JUSTICE XI" size="HorizCard">
+  <card id="f69b2d45-3917-4679-a48a-b6c32d47e874" name="JUSTICE · XI" size="HorizCard">
     <property name="Card Number" value="66"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="At Death's Doorstep"/>

--- a/o8g/Sets/The City of Archives/set.xml
+++ b/o8g/Sets/The City of Archives/set.xml
@@ -104,14 +104,16 @@
     <property name="Card Number" value="237"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The City of Archives"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="α: -1 (-3 instead if you have 5 or more cards in your hand).&#10;γ: -3. If you fail, discard 1 random card from your hand.&#10;β or δ: -2. If you fail, place 1 of your clues on your location."/>
+    <property name="Text" value="α: -1 (-3 instead if you have 5 or more cards in your hand).&#10;β δ: -2. If you fail, place 1 of your clues on your location.&#10;γ: -3. If you fail, discard 1 random card from your hand."/>
     <alternate name="The City of Archives" type="B">
       <property name="Encounter Set" value="The City of Archives"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="α: -2 (if you have 5 or more cards in your hand, you automatically fail instead).&#10;γ: -3. For each point you fail by, discard 1 random card from your hand.&#10;β or δ: -2. Place 1 of your clues on your location."/>
+      <property name="Text" value="α: -2 (if you have 5 or more cards in your hand, you automatically fail instead).&#10;β δ: -2. Place 1 of your clues on your location.&#10;γ: -3. For each point you fail by, discard 1 random card from your hand."/>
     </alternate>
   </card>
   <card id="599b455a-1ed9-4a8b-8de3-cd48b86652d4" name="City of the Great Race" size="HorizCard">
@@ -164,7 +166,7 @@
     <property name="Clues" value=""/>
     <property name="Doom" value="7"/>
     <property name="Text" value="Each investigator's maximum hand size is reduced by 4."/>
-    <alternate name="Alien Existance" size="HorizCard" type="B">
+    <alternate name="Alien Existence" size="HorizCard" type="B">
       <property name="Encounter Set" value="The City of Archives"/>
       <property name="Type" value="Agenda"/>
       <property name="Class" value="Mythos"/>
@@ -237,6 +239,7 @@
   <card id="866e3e89-94bb-4f57-9caf-96904f3ee338" name="Body of a Yithian" size="InvestigatorCard">
     <property name="Card Number" value="244"/>
     <property name="Quantity" value="4"/>
+    <property name="Subtitle" value="Captive in Another Form"/>
     <property name="Encounter Set" value="The City of Archives"/>
     <property name="Type" value="Investigator"/>
     <property name="Class" value="Mythos"/>

--- a/o8g/Sets/The Depths of Yoth/set.xml
+++ b/o8g/Sets/The Depths of Yoth/set.xml
@@ -158,14 +158,16 @@
     <property name="Card Number" value="277"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Depths of Yoth"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;&#10;α: -X. X is the current depth level.&#10;&#10;β: Reveal another token. If you fail, each [[Serpent]] enemy at your location or a connecting location heals 2 damage.&#10;&#10;γ: Reveal another token. If you fail, place 1 clue on your location (from the token pool).&#10;&#10;δ: -2. If there are 3 or more vengeance points in the victory display, you automatically fail this test, instead."/>
+    <property name="Text" value="α: -X. X is the current depth level.#10;β: Reveal another token. If you fail, each [[Serpent]] enemy at your location or a connecting location heals 2 damage.&#10;γ: Reveal another token. If you fail, place 1 clue on your location (from the token pool).&#10;δ: -2. If there are 3 or more vengeance points in the victory display, you automatically fail this test, instead."/>
     <alternate name="The Depths of Yoth" type="B">
       <property name="Encounter Set" value="The Depths of Yoth"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;&#10;α: -X. X is the current depth level. If you fail, take 1 horror.&#10;&#10;β: Reveal another token. If you fail, each [[Serpent]] enemy at your location or a connecting location heals 2 damage.&#10;&#10;γ: Reveal another token. If you fail, place 1 clue on your location (from the token pool).&#10;&#10;δ: -4. If there are 3 or more vengeance points in the victory display, you automatically fail this test, instead."/>
+      <property name="Text" value="α: -X. X is the current depth level. If you fail, take 1 horror.&#10;β: Reveal another token. If you fail, each [[Serpent]] enemy at your location or a connecting location heals 2 damage.&#10;γ: Reveal another token. If you fail, place 1 clue on your location (from the token pool).&#10;δ: -4. If there are 3 or more vengeance points in the victory display, you automatically fail this test, instead."/>
     </alternate>
   </card>
   <card id="3fc2759d-a3a7-45b2-be16-854895115bbc" name="The Descent Begins" size="HorizCard">

--- a/o8g/Sets/The Dream-Eaters/set.xml
+++ b/o8g/Sets/The Dream-Eaters/set.xml
@@ -207,6 +207,7 @@
     <card id="9b766310-ccb6-43e2-a84e-4215a70fd31a" name="Gate Box">
       <property name="Card Number" value="13" />
       <property name="Quantity" value="1" />
+      <property name="Subtitle" value="Worlds within Worlds"/>
       <property name="Type" value="Asset" />
       <property name="Traits" value="Item. Relic." />
       <property name="Text" value="Luke Robinson deck only. Uses (3 charges).&#10;θ Exhaust Gate Box and spend 1 charge: Disengage from each enemy engaged with you, search your bonded cards for Dream-Gate (Wondrous Journey), put it into play, and move to it." />
@@ -231,7 +232,7 @@
     <card id="3330e3db-e28a-4901-a3bd-077c7aceeb7f" name="Dream-Gate">
       <property name="Card Number" value="15" />
       <property name="Quantity" value="1" />
-      <property name="Subtitle" value="Wonderous Journey" />
+      <property name="Subtitle" value="Wondrous Journey" />
       <property name="Type" value="Location" />
       <property name="Traits" value="Dreamlands." />
       <property name="Text" value="Bonded (Gate Box).&#10;Dream-Gate is connected to each other revealed location, and vice versa. Enemies and investigators other than Luke Robinson cannot enter Dream-Gate.&#10;Forced – At the end of the investigation phase: Set Dream-Gate aside, out of play. (If Luke Robinson is here, move him to any revealed location.)" />
@@ -592,12 +593,12 @@
       <property name="Encounter Set" value="Beyond the Gates of Sleep" />
       <property name="Subtitle" value="EASY / STANDARD" />
       <property name="Type" value="Scenario" />
-      <property name="Text" value="α : –X. X is half the number of cards in your hand (rounded up).&#10;β: –X. X is the number of revealed Enchanted Woods locations.&#10;γ: –2. If you fail and this is an attack or evasion attempt against a swarming enemy, add 1 swarm card to it." />
+      <property name="Text" value="α: –X. X is half the number of cards in your hand (rounded up).&#10;β: –X. X is the number of revealed Enchanted Woods locations.&#10;γ: –2. If you fail and this is an attack or evasion attempt against a swarming enemy, add 1 swarm card to it." />
       <alternate name="Beyond the Gates of Sleep" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Beyond the Gates of Sleep" />
         <property name="Subtitle" value="HARD / EXPERT" />
         <property name="Type" value="Scenario" />
-        <property name="Text" value="α : –X. X is the number of cards in your hand.&#10;β: –X. X is the number of revealed Woods locations.&#10;γ: –2. If this is an attack or evasion attempt against a swarming enemy, add 1 swarm card to it." />
+        <property name="Text" value="α: –X. X is the number of cards in your hand.&#10;β: –X. X is the number of revealed Woods locations.&#10;γ: –2. If this is an attack or evasion attempt against a swarming enemy, add 1 swarm card to it." />
       </alternate>
     </card>
     <card id="19db1533-dc1f-4aab-9293-ee128a21942a" name="Journey through the Gates" size="HorizCard">
@@ -968,12 +969,12 @@
       <property name="Encounter Set" value="Waking Nightmare" />
       <property name="Subtitle" value="EASY / STANDARD" />
       <property name="Type" value="Scenario" />
-      <property name="Text" value="α : –1 (–3 instead if you are engaged with a Staff enemy).β: Reveal another chaos token. If you fail and it is agenda 2 or 3, make an infestation test.&#10;δ: –X. X is the number of infested locations." />
+      <property name="Text" value="α: –1 (–3 instead if you are engaged with a Staff enemy).&#10;β: Reveal another chaos token. If you fail and it is agenda 2 or 3, make an infestation test.&#10;δ: –X. X is the number of infested locations." />
       <alternate name="Waking Nightmare" size="EncounterCard" type="B">
         <property name="Encounter Set" value="Waking Nightmare" />
         <property name="Subtitle" value="HARD / EXPERT" />
         <property name="Type" value="Scenario" />
-        <property name="Text" value="α : –2 (–4 instead if you are engaged with a Staff enemy).&#10;β: Reveal another chaos token. If it is agenda 2 or 3, make an infestation test.&#10;δ: –X. X is 1 higher than the number of infested locations." />
+        <property name="Text" value="α: –2 (–4 instead if you are engaged with a Staff enemy).&#10;β: Reveal another chaos token. If it is agenda 2 or 3, make an infestation test.&#10;δ: –X. X is 1 higher than the number of infested locations." />
       </alternate>
     </card>
     <card id="93f1ba7c-ee75-4780-ae78-737f3b2abfff" name="Halls of St. Mary’s" size="HorizCard">
@@ -1190,7 +1191,7 @@
         <property name="Clues" value="0" />
       </alternate>
     </card>
-    <card id="4f315e5b-2958-4036-ae66-0b27d965024c" name="The Infestation Begins..." size="EncounterCard">
+    <card id="4f315e5b-2958-4036-ae66-0b27d965024c" name="The Infestation Begins…" size="EncounterCard">
       <property name="Card Number" value="78" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="Waking Nightmare" />

--- a/o8g/Sets/The Essex County Express/set.xml
+++ b/o8g/Sets/The Essex County Express/set.xml
@@ -154,7 +154,7 @@
       <property name="Encounter Set" value="The Essex County Express"/>
       <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="α: -X. X is 1 more than the current Agenda #.&#10;β: Reveal another token. If you fail and it is your turn, lose all remaining actions and end your turn immediately..&#10;γ: -4. Add 1 doom token to each Cultist enemy in play.δ: -3. If you fail, choose and discard a card from your hand for each point you failed by."/>
+      <property name="Text" value="α: -X. X is 1 more than the current Agenda #.&#10;β: Reveal another token. If you fail and it is your turn, lose all remaining actions and end your turn immediately.&#10;γ: -4. Add 1 doom token to each Cultist enemy in play.&#10;δ: -3. If you fail, choose and discard a card from your hand for each point you failed by."/>
     </alternate>
   </card>
   <card id="7c0d58a3-923e-4166-bcb7-21103a12c87d" name="A Tear in Reality" size="HorizCard">

--- a/o8g/Sets/The Forgotten Age/set.xml
+++ b/o8g/Sets/The Forgotten Age/set.xml
@@ -583,14 +583,16 @@
     <property name="Card Number" value="43"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Untamed Wilds"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;&#10;α: -X. X is the number of vengeance points in the victory display.&#10;&#10;β: -X. X is the number of locations in play (max 5).&#10;&#10;γ: -X. X is the number of cards in the exploration deck (max 5).&#10;&#10;δ: -2. If you are poisoned, this test automatically fails instead."/>
+    <property name="Text" value="α: -X. X is the number of vengeance points in the victory display.&#10;β: -X. X is the number of locations in play (max 5).&#10;γ: -X. X is the number of cards in the exploration deck (max 5).&#10;δ: -2. If you are poisoned, this test automatically fails instead."/>
     <alternate name="The Untamed Wilds" type="B">
       <property name="Encounter Set" value="The Untamed Wilds"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;&#10;α: -X. X is 1 higher than the number of vengeance points in the victory display.&#10;&#10;β: -X. X is the number of locations in play.&#10;&#10;γ: -X. X is the number of cards in the exploration deck (min 3).&#10;&#10;δ: -3. If you are poisoned, this test automatically fails instead. If you are not poisoned and you fail, put a set-aside Poisoned weakness into play in your threat area."/>
+      <property name="Text" value="α: -X. X is 1 higher than the number of vengeance points in the victory display.&#10;β: -X. X is the number of locations in play.&#10;γ: -X. X is the number of cards in the exploration deck (min 3).&#10;δ: -3. If you are poisoned, this test automatically fails instead. If you are not poisoned and you fail, put a set-aside Poisoned weakness into play in your threat area."/>
     </alternate>
   </card>
   <card id="cf16a4b5-94ef-48af-8493-39999789746f" name="Expedition into the Wild" size="HorizCard">
@@ -797,14 +799,16 @@
     <property name="Card Number" value="54"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Doom of Eztli"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;&#10;α: -1 (-3 instead if there is doom on your location).&#10;&#10;β γ: -X. X is the number of locations with doom on them.&#10;&#10;δ: Reveal another chaos token. If you fail, place 1 doom on your location."/>
+    <property name="Text" value="α: -1 (-3 instead if there is doom on your location).&#10;β γ: -X. X is the number of locations with doom on them.&#10;δ: Reveal another chaos token. If you fail, place 1 doom on your location."/>
     <alternate name="The Doom of Eztli" type="B">
       <property name="Encounter Set" value="The Doom of Eztli"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;&#10;α: -2 (-4 instead if there is doom on your location).&#10;&#10;β γ: -X. X is the total amount of doom on locations in play.&#10;&#10;δ: Reveal another chaos token. Place 1 doom on your location."/>
+      <property name="Text" value="α: -2 (-4 instead if there is doom on your location).&#10;β γ: -X. X is the total amount of doom on locations in play.&#10;δ: Reveal another chaos token. Place 1 doom on your location."/>
     </alternate>
   </card>
   <card id="e8557d55-2e3e-4ecd-bea1-25560e5055c9" name="Something Stirs…" size="HorizCard">

--- a/o8g/Sets/The Labyrinths of Lunacy/set.xml
+++ b/o8g/Sets/The Labyrinths of Lunacy/set.xml
@@ -5,14 +5,16 @@
     <property name="Card Number" value="1"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Labyrinths of Lunacy"/>
+    <property name="Subtitle" value="STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Standard&#10;&#10;α: -1. Reveal another token.&#10;&#10;β: -3. If you fail, place 1 of your clues on your location.&#10;&#10;γ: -4. If you fail, lose 2 resources.&#10;&#10;δ: -4. If you fail, discard a random card from your hand."/>
+    <property name="Text" value="α: -1. Reveal another token.&#10;β: -3. If you fail, place 1 of your clues on your location.&#10;γ: -4. If you fail, lose 2 resources.&#10;δ: -4. If you fail, discard a random card from your hand."/>
     <alternate name="The Labyrinths of Lunacy" type="B">
       <property name="Encounter Set" value="The Labyrinths of Lunacy"/>
+      <property name="Subtitle" value="HARD"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard&#10;&#10;α: -1. Reveal another token. If you fail, you must either take 1&amp;nbsp;damage or 1 horror.&#10;&#10;β: -3. Place 1 of your clues on your location.&#10;&#10;γ: -4. Lose 2 resources.&#10;&#10;δ: -4. Discard a random card from your hand."/>
+      <property name="Text" value="α: -1. Reveal another token. If you fail, you must either take 1 damage or 1 horror.&#10;β: -3. Place 1 of your clues on your location.&#10;γ: -4. Lose 2 resources.&#10;δ: -4. Discard a random card from your hand."/>
     </alternate>
   </card>
   <card id="f555a583-ef14-428c-8382-f80a67ea873c" name="Awakening" size="HorizCard">

--- a/o8g/Sets/The Lair of Dagon/set.xml
+++ b/o8g/Sets/The Lair of Dagon/set.xml
@@ -17,6 +17,7 @@
     <card id="18bd958a-b948-4ebe-81e1-560debea28f8" name="Nepththys">
       <property name="Card Number" value="262" />
       <property name="Quantity" value="2" />
+      <property name="Subtitle" value="Huntress of Bast"/>
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ally. Blessed." />
       <property name="Text" value="You get +1 ά.&#10;ι When 1 or more [Bless] tokens would be removed from the chaos bag during a test: Seal them on Nephthys, instead.&#10;θ Exhaust Nephthys: Either release 3 [Bless] tokens sealed on her, or return 3 [Bless] tokens sealed on her to the token pool to deal 2 damage to an enemy at your location." />
@@ -473,7 +474,7 @@
         <property name="Victory Points" value="1" />
       </alternate>
     </card>
-    <card id="c004574d-7773-4569-bd7a-548a96335ce6" name="Apoostle of Dagon" size="EncounterCard">
+    <card id="c004574d-7773-4569-bd7a-548a96335ce6" name="Apostle of Dagon" size="EncounterCard">
       <property name="Card Number" value="293" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="The Lair of Dagon" />

--- a/o8g/Sets/The Miskatonic Museum/set.xml
+++ b/o8g/Sets/The Miskatonic Museum/set.xml
@@ -15,6 +15,7 @@
   <card id="ddbccff0-827e-44a9-8c28-07d5e8e3fea5" name="Brother Xavier">
     <property name="Card Number" value="106"/>
     <property name="Quantity" value="2"/>
+    <property name="Subtitle" value="Pure of Spirit"/>
     <property name="Unique" value="ο"/>
     <property name="Type" value="Asset"/>
     <property name="Class" value="Guardian"/>

--- a/o8g/Sets/The Pallid Mask/set.xml
+++ b/o8g/Sets/The Pallid Mask/set.xml
@@ -155,14 +155,16 @@
     <property name="Card Number" value="240"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Pallid Mask"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;α: -X. X is the number of locations away from the starting location you are (max 5).&#10;β: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.&#10;γ: -2. If there is a ready Ghoul or Geist enemy at your location, it attacks you (if there is more than one, choose one).&#10;δ: -3. If you fail, search the encounter deck and discard pile for a Ghoul or Geist enemy and draw it."/>
+    <property name="Text" value="α: -X. X is the number of locations away from the starting location you are (max 5).&#10;β: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.&#10;γ: -2. If there is a ready Ghoul or Geist enemy at your location, it attacks you (if there is more than one, choose one).&#10;δ: -3. If you fail, search the encounter deck and discard pile for a Ghoul or Geist enemy and draw it."/>
     <alternate name="The Pallid Mask" type="B">
       <property name="Encounter Set" value="The Pallid Mask"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;α: -X. X is the number of locations away from the starting location you are.&#10;β: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.&#10;γ: -3. If there is a Ghoul or Geist enemy at your location, it readies and attacks you (if there is more than one, choose one).&#10;δ: -4. If you fail, search the encounter deck and discard pile for a Ghoul or Geist enemy and draw it."/>
+      <property name="Text" value="α: -X. X is the number of locations away from the starting location you are.&#10;β: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.&#10;γ: -3. If there is a Ghoul or Geist enemy at your location, it readies and attacks you (if there is more than one, choose one).&#10;δ: -4. If you fail, search the encounter deck and discard pile for a Ghoul or Geist enemy and draw it."/>
     </alternate>
   </card>
   <card id="7cc80dae-6a90-4d31-9e4b-b892ad1ff4ba" name="Empire of the Dead" size="HorizCard">

--- a/o8g/Sets/The Search for Kadath/set.xml
+++ b/o8g/Sets/The Search for Kadath/set.xml
@@ -145,12 +145,14 @@
       <property name="Card Number" value="119" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="The Search for Kadath" />
+      <property name="Subtitle" value="EASY / STANDARD"/>
       <property name="Type" value="Scenario" />
-      <property name="Text" value="α : –X. X is the number of Signs of the Gods the investigators have uncovered.&#10;β: Reveal another token. If this token is revealed during an investigation and this skill test fails, increase this location’s shroud by 1 for the remainder of the round.&#10;γ: –2. If you fail, either take 1 damage and 1 horror, or place 1 doom on the current agenda.&#10;δ: +2. The black cat points you in the right direction. If this token is revealed during an investigation and you succeed, discover 1 additional clue." />
+      <property name="Text" value="α: –X. X is the number of Signs of the Gods the investigators have uncovered.&#10;β: Reveal another token. If this token is revealed during an investigation and this skill test fails, increase this location’s shroud by 1 for the remainder of the round.&#10;γ: –2. If you fail, either take 1 damage and 1 horror, or place 1 doom on the current agenda.&#10;δ: +2. The black cat points you in the right direction. If this token is revealed during an investigation and you succeed, discover 1 additional clue." />
       <alternate name="The Search for Kadath" size="EncounterCard" type="B">
         <property name="Encounter Set" value="The Search for Kadath" />
+        <property name="Subtitle" value="HARD / EXPERT"/>
         <property name="Type" value="Scenario" />
-        <property name="Text" value="α : –X. X is 1 more than the number of Signs of the Gods the investigators have uncovered.&#10;β: Reveal another token. If this token is revealed during an investigation and this skill test fails, increase this location’s shroud by 2 for the remainder of the round.&#10;γ: –3. If you fail, either take 1 damage and 1 horror, or place 1 doom on the current agenda.&#10;δ: +1. The black cat points you in the right direction. If this token is revealed during an investigation and you succeed, discover 1 additional clue." />
+        <property name="Text" value="α: –X. X is 1 more than the number of Signs of the Gods the investigators have uncovered.&#10;β: Reveal another token. If this token is revealed during an investigation and this skill test fails, increase this location’s shroud by 2 for the remainder of the round.&#10;γ: –3. If you fail, either take 1 damage and 1 horror, or place 1 doom on the current agenda.&#10;δ: +1. The black cat points you in the right direction. If this token is revealed during an investigation and you succeed, discover 1 additional clue." />
       </alternate>
     </card>
     <card id="0fc565c2-467d-4419-9858-fa968ba5679f" name="Journey Across the Dreamlands" size="HorizCard">

--- a/o8g/Sets/The Unspeakable Oath/set.xml
+++ b/o8g/Sets/The Unspeakable Oath/set.xml
@@ -163,12 +163,14 @@
     <property name="Card Number" value="159"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="The Unspeakable Oath"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="Easy / Standard&#10;α: -1. If you fail, randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it.&#10;β: -X. X is the amount of horror on you.&#10;γ: -X. X is the base shroud value of your location.&#10;δ: 0. Either randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it, or this test automatically fails instead."/>
+    <property name="Text" value="α: -1. If you fail, randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it.&#10;β: -X. X is the amount of horror on you.&#10;γ: -X. X is the base shroud value of your location.&#10;δ: 0. Either randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it, or this test automatically fails instead."/>
     <alternate name="The Unspeakable Oath" type="B">
       <property name="Encounter Set" value="The Unspeakable Oath"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="Hard / Expert&#10;α: Reveal another token. If you fail, randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it. (Limit once per test.)&#10;β: -X. X is the amount of horror on you. If you fail, take 1 horror.&#10;γ: -X. X is the base shroud value of your location. If you fail, take 1 horror.&#10;δ: 0. Either randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it, or this test automatically fails instead."/>
+      <property name="Text" value="α: Reveal another token. If you fail, randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it. (Limit once per test.)&#10;β: -X. X is the amount of horror on you. If you fail, take 1 horror.&#10;γ: -X. X is the base shroud value of your location. If you fail, take 1 horror.&#10;δ: 0. Either randomly choose an enemy from among the set-aside Monster enemies and place it beneath the act deck without looking at it, or this test automatically fails instead."/>
     </alternate>
   </card>
   <card id="a3789f6e-a6a7-48e6-838b-8bec7ae6a952" name="Locked Inside" size="HorizCard">

--- a/o8g/Sets/The Wages of Sin/set.xml
+++ b/o8g/Sets/The Wages of Sin/set.xml
@@ -83,7 +83,7 @@
       <property name="Sanity" value="2" />
       <property name="Class" value="Rogue" />
       <property name="Level" value="0" />
-      <property name="Cost" value="2" />
+      <property name="Cost" value="3" />
       <property name="Willpower" value="0" />
       <property name="Intellect" value="0" />
       <property name="Combat" value="0" />
@@ -234,7 +234,7 @@
       <property name="Subtitle" value="Act 2a" />
       <property name="Type" value="Act" />
       <property name="Text" value="θ: Flip your location over. (Group limit once per round at each location.)&#10;Clues cannot be discovered at non-Spectral locations.&#10;Objective – Banish as many Heretics as you can. If there are 4 copies of Unfinished Business in the victory display, advance." />
-      <alternate name="Was It Worth It?" size="HorizCard" type="B">
+      <alternate name="Was it Worth It?" size="HorizCard" type="B">
         <property name="Encounter Set" value="The Wages of Sin" />
         <property name="Subtitle" value="Act 2b" />
         <property name="Type" value="Act" />
@@ -591,7 +591,7 @@
       <property name="Traits" value="Omen." />
       <property name="Text" value="Peril.&#10;Revelation – You must either (choose one):&#10;—Draw the top card of the spectral encounter deck. That card gains peril, and its effects cannot be canceled.&#10;—Test ά (3). If you fail, take 2 horror." />
     </card>
-    <card id="1529b14f-ab18-4db9-841a-b0b603f1efde" name="Grave-light" size="EncounterCard">
+    <card id="1529b14f-ab18-4db9-841a-b0b603f1efde" name="Grave-Light" size="EncounterCard">
       <property name="Card Number" value="184" />
       <property name="Quantity" value="2" />
       <property name="Encounter Set" value="The Wages of Sin" />

--- a/o8g/Sets/Threads of Fate/set.xml
+++ b/o8g/Sets/Threads of Fate/set.xml
@@ -123,14 +123,16 @@
     <property name="Card Number" value="113"/>
     <property name="Quantity" value="1"/>
     <property name="Encounter Set" value="Threads of Fate"/>
+    <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
     <property name="Class" value="Mythos"/>
-    <property name="Text" value="Easy / Standard&#10;&#10;α : -X. X is the highest number of doom on a [β] enemy.&#10;&#10;β: -2. If you do not succeed by at least 1, take 1 damage.&#10;&#10;γ: -2. If you do not succeed by at least 1, place 1 doom on the nearest [β] enemy.&#10;&#10;δ: -2. If you fail, lose 1 of your clues."/>
+    <property name="Text" value="α : -X. X is the highest number of doom on a Cultist enemy.&#10;β: -2. If you do not succeed by at least 1, take 1 damage.&#10;γ: -2. If you do not succeed by at least 1, place 1 doom on the nearest Cultist enemy.&#10;δ: -2. If you fail, lose 1 of your clues."/>
     <alternate name="Threads of Fate" type="B">
       <property name="Encounter Set" value="Threads of Fate"/>
+      <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
       <property name="Class" value="Mythos"/>
-      <property name="Text" value="Hard / Expert&#10;&#10;α : -X. X is the total number of doom in play.&#10;&#10;β: -2. If you do not succeed by at least 2, take 1 direct damage.&#10;&#10;γ: -2. If you do not succeed by at least 2, place 1 doom on each [β] enemy.&#10;&#10;δ: -3. If you fail, lose 1 of your clues."/>
+      <property name="Text" value="α : -X. X is the total number of doom in play.&#10;β: -2. If you do not succeed by at least 2, take 1 direct damage.&#10;γ: -2. If you do not succeed by at least 2, place 1 doom on each Cultist enemy.&#10;δ: -3. If you fail, lose 1 of your clues."/>
     </alternate>
   </card>
   <card id="c4993b69-869c-454a-9bba-9cc7eb6f884a" name="Three Fates" size="HorizCard">

--- a/o8g/Sets/Undimensioned and Unseen/set.xml
+++ b/o8g/Sets/Undimensioned and Unseen/set.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <set xmlns:noNamespaceSchemaLocation="CardSet.xsd" name="Undimensioned and Unseen" id="aeafbc38-6263-37a4-2faf-a51e9899f154" gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" version="1.0.0">
  <cards>
-  <card id="bc9c240e-8ce5-3125-03cc-d00ed2265f3c" name="&quot;If it bleeds...&quot;">
+  <card id="bc9c240e-8ce5-3125-03cc-d00ed2265f3c" name="&quot;If it bleeds…&quot;">
     <property name="Card Number" value="225"/>
     <property name="Quantity" value="2"/>
     <property name="Type" value="Event"/>
@@ -63,6 +63,7 @@
   <card id="ddc63adf-ce89-32d4-d646-da0ed6f6a53e" name="Lucky Dice">
     <property name="Card Number" value="230"/>
     <property name="Quantity" value="2"/>
+    <property name="Subtitle" value="…Or Are They?"/>
     <property name="Type" value="Asset"/>
     <property name="Class" value="Rogue"/>
     <property name="Level" value="2"/>

--- a/o8g/Sets/Union and Disillusion/set.xml
+++ b/o8g/Sets/Union and Disillusion/set.xml
@@ -501,7 +501,7 @@
       <property name="Card Number" value="260" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="Union and Disillusion" />
-      <property name="Subtitle" value="The Nightmare Is Over" />
+      <property name="Subtitle" value="The Nightmare is Over" />
       <property name="Type" value="Asset" />
       <property name="Traits" value="Ally. Assistant." />
       <property name="Text" value="You get +1 ά.&#10;ι After you succeed at a skill test during a revelation effect, exhaust Penny White: Discover 1 clue at your location." />
@@ -566,7 +566,7 @@
       <property name="Victory Points" value="0" />
       <alternate name="Jerome Davids" type="B">
         <property name="Encounter Set" value="Union and Disillusion" />
-        <property name="Subtitle" value="Starved For Answers" />
+        <property name="Subtitle" value="Starved for Answers" />
         <property name="Type" value="Enemy" />
         <property name="Traits" value="Humanoid. Geist. Sprectal. Elite." />
         <property name="Text" value="Hunter.&#10;Forced – After Jerome Davids engages you: Choose and discard 2 cards from your hand." />

--- a/o8g/Sets/War of the Outer Gods/set.xml
+++ b/o8g/Sets/War of the Outer Gods/set.xml
@@ -22,7 +22,7 @@
       <property name="Subtitle" value="Agenda 1a" />
       <property name="Type" value="Agenda" />
       <property name="Text" value="*This agenda has a global doom threshold of 6 per group.&#10;Forced – When this agenda advances:&#10;If you are playing in Single Group Mode, remove 6 doom from it and move all excess doom to the next blue agenda.&#10;If you are playing in Epic Multiplayer Mode, move all doom and wards from it to the next blue agenda." />
-      <alternate name="Reinforcement" type="B" size="HorizCard">
+      <alternate name="Reinforcements" type="B" size="HorizCard">
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Subtitle" value="Agenda 1b" />
         <property name="Type" value="Agenda" />
@@ -64,7 +64,7 @@
       <property name="Subtitle" value="Agenda 1a" />
       <property name="Type" value="Agenda" />
       <property name="Text" value="*This agenda has a global doom threshold of 6 per group.&#10;Forced – When this agenda advances:&#10;If you are playing in Single Group Mode, remove 6 doom from it and move all excess doom to the next green agenda.&#10;If you are playing in Epic Multiplayer Mode, move all doom and wards from it to the next green agenda." />
-      <alternate name="Reinforcement" type="B" size="HorizCard">
+      <alternate name="Reinforcements" type="B" size="HorizCard">
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Subtitle" value="Agenda 1b" />
         <property name="Type" value="Agenda" />
@@ -106,21 +106,21 @@
       <property name="Subtitle" value="Agenda 1a" />
       <property name="Type" value="Agenda" />
       <property name="Text" value="*This agenda has a global doom threshold of 6 per group.&#10;Forced – When this agenda advances:&#10;If you are playing in Single Group Mode, remove 6 doom from it and move all excess doom to the next red agenda.&#10;If you are playing in Epic Multiplayer Mode, move all doom and wards from it to the next red agenda." />
-      <alternate name="Reinforcement" type="B" size="HorizCard">
+      <alternate name="Reinforcements" type="B" size="HorizCard">
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Subtitle" value="Agenda 1b" />
         <property name="Type" value="Agenda" />
         <property name="Text" value="If you are playing in Standalone Mode, add 1 δ token to the chaos bag.&#10;Shuffle 3 of the 4 set-aside Trylogog enemies, the 2 Transmogrify treacheries, and the encounter discard pile into the encounter deck.&#10;If this is the first agenda to advance to 1b, spawn the remaining set-aside Trylogog enemy. That enemy gains an additional swarming 2." />
       </alternate>
     </card>
-    <card id="d119691b-36f6-4e54-82e4-e12264b3520a" name="The Swarm Spreads" size="HorizCard">
+    <card id="d119691b-36f6-4e54-82e4-e12264b3520a" name="The Proliferation Progresses" size="HorizCard">
       <property name="Card Number" value="9" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="War of the Outer Gods" />
       <property name="Subtitle" value="Agenda 2a" />
       <property name="Type" value="Agenda" />
       <property name="Text" value="*This agenda has a global doom threshold of 6 per group.&#10;Forced – When this agenda advances:&#10;If you are playing in Single Group Mode, remove 6 doom from it and move all excess doom to the next red agenda.&#10;If you are playing in Epic Multiplayer Mode, move all doom and wards from it to the next red agenda." />
-      <alternate name="Summoning of the Servitor" type="B" size="HorizCard">
+      <alternate name="The Swarm Spreads" type="B" size="HorizCard">
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Subtitle" value="Agenda 2b" />
         <property name="Type" value="Agenda" />
@@ -138,7 +138,7 @@
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Subtitle" value="Agenda 3b" />
         <property name="Type" value="Agenda" />
-        <property name="Text" value="If you are playing in Standalone Mode, add 1 δ token to the chaos bag.&#10;Flip Hub Dimension to its (Gateway to Destruction) side. If Hub Dimension is not in play, put it into play, (Gateway to Destruction) side faceup.&#10;Spawn the set-aside Ezel-zen-rezl enemy at Hub Dimension.&#10;Search the encounter deck, encounter discard pile, and each play area for all blue and green encounter cards and remove them from the game. Shuffle the encounter deck. Remove each agenda and act from the game and put the set-aside The Swarm Spreads agenda into play." />
+        <property name="Text" value="If you are playing in Standalone Mode, add 1 δ token to the chaos bag.&#10;Flip Hub Dimension to its (Gateway to Destruction) side. If Hub Dimension is not in play, put it into play, (Gateway to Destruction) side faceup.&#10;Spawn the set-aside Ezel-zen-rezl enemy at Hub Dimension.&#10;Search the encounter deck, encounter discard pile, and each play area for all blue and green encounter cards and remove them from the game. Shuffle the encounter deck. Remove each agenda and act from the game and put the set-aside Ezel-zen-rezl Emerges agenda into play." />
       </alternate>
     </card>
     <card id="dc674602-0be0-4878-8583-2fdeb2d71aa8" name="War of the Outer Gods" size="HorizCard">
@@ -246,17 +246,17 @@
         <property name="Clues" value="1π" />
       </alternate>
     </card>
-    <card id="f51c51cb-535d-4dea-9ef7-34fdebc52df8" name="Streets of Montreal" size="EncounterCard">
+    <card id="f51c51cb-535d-4dea-9ef7-34fdebc52df8" name="Streets of Montréal" size="EncounterCard">
       <property name="Card Number" value="18" />
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="War of the Outer Gods" />
       <property name="Type" value="Location" />
-      <property name="Traits" value="Montreal." />
-      <alternate name="Streets of Montreal" type="B" size="EncounterCard">
+      <property name="Traits" value="Montréal." />
+      <alternate name="Streets of Montréal" type="B" size="EncounterCard">
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Type" value="Location" />
-        <property name="Traits" value="Montreal." />
-        <property name="Text" value="η η Deal 3 damage to a non-Ancient One enemy at a Montreal location in any group. (Group limit once per game.)" />
+        <property name="Traits" value="Montréal." />
+        <property name="Text" value="η η Deal 3 damage to a non-Ancient One enemy at a Montréal location in any group. (Group limit once per game.)" />
         <property name="Shroud" value="4" />
         <property name="Clues" value="1π" />
         <property name="Victory Points" value="1" />
@@ -267,11 +267,11 @@
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="War of the Outer Gods" />
       <property name="Type" value="Location" />
-      <property name="Traits" value="Montreal." />
+      <property name="Traits" value="Montréal." />
       <alternate name="Chateau Ramezay" type="B" size="EncounterCard">
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Type" value="Location" />
-        <property name="Traits" value="Montreal." />
+        <property name="Traits" value="Montréal." />
         <property name="Text" value="η Test ά (4). If you succeed, gain 1 clue (from the token pool)." />
         <property name="Shroud" value="2" />
         <property name="Clues" value="1π" />
@@ -282,11 +282,11 @@
       <property name="Quantity" value="1" />
       <property name="Encounter Set" value="War of the Outer Gods" />
       <property name="Type" value="Location" />
-      <property name="Traits" value="Ritual Site. Montreal." />
+      <property name="Traits" value="Ritual Site. Montréal." />
       <alternate name="Shrine of Magh’an Ark’at" type="B" size="EncounterCard">
         <property name="Encounter Set" value="War of the Outer Gods" />
         <property name="Type" value="Location" />
-        <property name="Traits" value="Ritual Site. Montreal." />
+        <property name="Traits" value="Ritual Site. Montréal." />
         <property name="Text" value="θ Draw the top card of the encounter deck: Place 1 ward on the green agenda. (Group limit once per round.)" />
         <property name="Shroud" value="3" />
         <property name="Clues" value="1π" />

--- a/o8g/Sets/Weaver of the Cosmos/set.xml
+++ b/o8g/Sets/Weaver of the Cosmos/set.xml
@@ -330,7 +330,7 @@
       <property name="Traits" value="Otherworld. Extradimensional." />
       <alternate name="The Great Web" type="B" size="EncounterCard">
         <property name="Encounter Set" value="Weaver of the Cosmos" />
-        <property name="Subtitle" value="Web-Woven island" />
+        <property name="Subtitle" value="Web-Woven Island" />
         <property name="Type" value="Location" />
         <property name="Traits" value="Otherworld. Extradimensional." />
         <property name="Text" value="As an additional cost to investigate this location, you must either spend 1 action or place 1 doom on this location." />

--- a/o8g/Sets/Where Doom Awaits/set.xml
+++ b/o8g/Sets/Where Doom Awaits/set.xml
@@ -184,12 +184,12 @@
     <property name="Encounter Set" value="Where Doom Awaits"/>
     <property name="Subtitle" value="EASY / STANDARD"/>
     <property name="Type" value="Scenario"/>
-    <property name="Text" value="α -1 (-3 instead if you are at an Altered location).&#10;β Reveal another token. Cancel the effects and icons of each skill card committed to this test.&#10;γ -2 (-4 instead if it is Agenda 2).&#10;δ -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards."/>
+    <property name="Text" value="α: -1 (-3 instead if you are at an Altered location).&#10;β: Reveal another token. Cancel the effects and icons of each skill card committed to this test.&#10;γ -2 (-4 instead if it is Agenda 2).&#10;δ: -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards."/>
     <alternate name="Where Doom Awaits" type="B">
       <property name="Encounter Set" value="Where Doom Awaits"/>
       <property name="Subtitle" value="HARD / EXPERT"/>
       <property name="Type" value="Scenario"/>
-      <property name="Text" value="α -2 (-5 instead if you are at an Altered location).&#10;β Reveal another token. Cancel the effects and icons of each skill card committed to this test.&#10;γ -3. If it is Agenda 2, you automatically fail instead.&#10;δ -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."/>
+      <property name="Text" value="α: -2 (-5 instead if you are at an Altered location).&#10;β: Reveal another token. Cancel the effects and icons of each skill card committed to this test.&#10;γ: -3. If it is Agenda 2, you automatically fail instead.&#10;δ: -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."/>
     </alternate>
   </card>
   <card id="a3c0d6f8-b99f-3379-18cc-dfcbd78f34e2" name="Calling Forth the Old Ones" size="HorizCard">


### PR DESCRIPTION
Went through all sets, except return to the circle undone, and fixed many typos, added missing subtitles, and made scenario reference cards consistent.