### PR TITLE
Update drawAddChaosToken

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1791,7 +1791,7 @@ def drawAddChaosToken(group, x = 0, y = 0):
     mute()
     num = 0
     for card in table: #find out how many Tokens there already are
-        if card.Type == "Chaos Token":
+        if card.Type == "Chaos Token" and card.subType != "Sealed":
             num += 1
 
     if chaosBag().controller == me:


### PR DESCRIPTION
Right now it takes into account every chaos token on the table, thus moving the additional chaos token quite far if alot of tokens are sealed (like in City of the Elder Things for example if players seal the chaos tokens on locations)