### PR TITLE
Save/Load function changes

### DIFF
--- a/o8g/Scripts/plugin.py
+++ b/o8g/Scripts/plugin.py
@@ -172,12 +172,6 @@ def restoreSave(group, x=0, y=0):
 	loadTable(phase)
 
 def loadTable(phase):
-	mute()
-	
-	if 1 != askChoice('You are about to LOAD the table states including the elements on the table, shared deck and each player\'s hand and piles.\nThis option should be execute on the a game host.'
-		, ['I am the Host!', 'I am not...'], ['#dd3737', '#d0d0d0']):
-		return
-	
 	if not getLock():
 		whisper("Others players are locking the table, please try again")
 		return

--- a/o8g/Scripts/plugin.py
+++ b/o8g/Scripts/plugin.py
@@ -114,6 +114,8 @@ def saveTable(phase):
 			for card in table:	
 				if card.owner == me or not isPlayerCard(card):
 					tab['table'].append(serializeCard(card))
+			# Save host cards
+			tab['players'] = [serializePlayer(Player(1))]
 
 		# loop and retrieve item from the shared decks
 			for p in shared.piles :


### PR DESCRIPTION
Right now the host being the only one to save the table and every card creates a problem after the load since every card is now the ownership of the host player, which then creates problems for solo players as well as in most card automation.

This update fixes this issue by making the host save the encounter cards and his player cards only.
Each other players save the cards they own.

After the loading, each player thus keeps the ownership of their cards.

The only "con" is that each player now has to save/load their game.