### PR TITLE
Minor bug fixes to actions.py

### DIFF
--- a/o8g/Scripts/actions.py
+++ b/o8g/Scripts/actions.py
@@ -1048,7 +1048,10 @@ def playerSetup(group=table, x=0, y=0, doPlayer=True, doEncounter=False):
                     addBless()
         isSuzi = filter(lambda card: "Subject 5U-21" in card.Name, me.hand)
         if isSuzi:
-            me.counters['Card Draw'].value = 2            
+            me.counters['Card Draw'].value = 2  
+	isHank = filter(lambda card: "Hank Samson" in card.Name, me.hand)
+        if isHank:
+            me.piles['Sideboard'].create('0b47ec14-d252-4692-9d78-90efd034ff8c')
         # Find any Start cards
         startCard = filter(lambda card: "Sophie" == card.Name or "Gate Box" == card.Name or "Duke" == card.Name or "Dark Insight" == card.Name or "Darrell's Kodak" == card.Name or card.Name == "On the Mend" or card.Name == "Ravenous", me.deck)
         # Create Bonded Card


### PR DESCRIPTION
FIX: Face-down double-sided cards could not be turned face up
FIX: Drawing an unrevealed card displayed the card name in the chat log
FIX: Selecting the "Mulligan" option displayed the cards in the reverse order from the Hand pane