### PR TITLE
TDC- Change set name property

### DIFF
--- a/o8g/Sets/The Drowned City Investigator Expansion/set.xml
+++ b/o8g/Sets/The Drowned City Investigator Expansion/set.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<set xmlns:noNamespaceSchemaLocation="CardSet.xsd" name="The Drowned City" id="43b23c56-f835-43be-b53d-feb3c3bc04bb" gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" version="1.0.0">
+<set xmlns:noNamespaceSchemaLocation="CardSet.xsd" name="The Drowned City Investigator Expansion" id="43b23c56-f835-43be-b53d-feb3c3bc04bb" gameId="a6d114c7-2e2a-4896-ad8c-0330605c90bf" gameVersion="1.0.0.0" version="1.0.0">
   <cards>
     <card id="c8fa6230-66c8-46f5-8b9c-baf5ca5e0df5" name="Marion Tavares" size="InvestigatorCard">
       <property name="Card Number" value="1" />


### PR DESCRIPTION
Deck generation for OCTGN on ArkhamDB doesn't work for the cards from this expansion. I think it's related to the name listed in the set.xml file.